### PR TITLE
Feat/disable permissions for subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Try to refresh existing sessions (0-click refresh)
 - Add confirm dialog when granting control permission
 - Load index eagerly when requesting info about container resources
+- Adds a switch will remove the access of a user. It preserves the given permissions in the index & will prevent remote from overwriting these when an item is disabled
+

--- a/controller/src/classes/Controller.ts
+++ b/controller/src/classes/Controller.ts
@@ -38,7 +38,7 @@ export class Controller<T extends Record<keyof T, BaseSubject<keyof T & string>>
         return this.getExistingRemotePermissions(resourceUrl, subject);
     }
 
-    private async updateItem<K extends SubjectKey<T>>(resourceUrl: string, subject: SubjectType<T, K>, permissions: Permission[], alwayKeepItem = false) {
+    private async updateItem<K extends SubjectKey<T>>(resourceUrl: string, subject: SubjectType<T, K>, permissions: Permission[], alwaysKeepItem = false) {
         let item = await this.getItem(resourceUrl, subject);
         const { manager } = this.getSubjectConfig(subject)
 
@@ -60,7 +60,7 @@ export class Controller<T extends Record<keyof T, BaseSubject<keyof T & string>>
             index.items.push(item);
         }
 
-        if (!alwayKeepItem && permissions.length === 0 && manager.shouldDeleteOnAllRevoked()) {
+        if (!alwaysKeepItem && permissions.length === 0 && manager.shouldDeleteOnAllRevoked()) {
             const index = await this.store.getCurrentIndex();
             const idx = index.items.findIndex(i => i.id === item.id);
             index.items.splice(idx, 1);

--- a/controller/src/classes/permissionManager/inrupt/GroupManager.ts
+++ b/controller/src/classes/permissionManager/inrupt/GroupManager.ts
@@ -50,7 +50,8 @@ export class GroupManager<T extends Record<keyof T, BaseSubject<keyof T & string
                 type: "webId",
                 selector: { url },
             } as T[K],
-            permissions: this.AccessModesToPermissions(access)
+            permissions: this.AccessModesToPermissions(access),
+            isEnabled: true,
         }))
     }
 }

--- a/controller/src/classes/permissionManager/inrupt/PublicManager.ts
+++ b/controller/src/classes/permissionManager/inrupt/PublicManager.ts
@@ -38,7 +38,8 @@ export class PublicManager<T extends Record<keyof T, BaseSubject<keyof T & strin
             subject: {
                 type: "public",
             } as T[K],
-            permissions: this.AccessModesToPermissions(publicAccess)
+            permissions: this.AccessModesToPermissions(publicAccess),
+            isEnabled: true,
         }]
     }
 }

--- a/controller/src/classes/permissionManager/inrupt/WebIdManager.ts
+++ b/controller/src/classes/permissionManager/inrupt/WebIdManager.ts
@@ -41,7 +41,8 @@ export class WebIdManager<T extends Record<keyof T, BaseSubject<keyof T & string
                 type: "webId",
                 selector: { url },
             } as T[K],
-            permissions: this.AccessModesToPermissions(access)
+            permissions: this.AccessModesToPermissions(access),
+            isEnabled: true,
         }))
     }
 }

--- a/controller/src/types/index.ts
+++ b/controller/src/types/index.ts
@@ -32,8 +32,9 @@ export interface BaseSubject<T extends string> {
 }
 
 export interface SubjectPermissions<T = BaseSubject<string>> {
-    subject: T,
-    permissions: Permission[]
+    subject: T;
+    permissions: Permission[];
+    isEnabled: boolean;
 }
 
 export interface ResourcePermissions<T = BaseSubject<string>> {

--- a/loama/src/components/explorer/SubjectPermissionTable.vue
+++ b/loama/src/components/explorer/SubjectPermissionTable.vue
@@ -39,7 +39,7 @@
             </Column>
             <Column header="Enabled">
                 <template #body="slotProps">
-                    <ToggleSwitch :modelValue="slotProps.data.isEnabled"
+                    <ToggleSwitch v-model="slotProps.data.isEnabled"
                         @update:modelValue="e => toggleSubjectAccess(e, slotProps.data.subject)" />
                 </template>
             </Column>

--- a/loama/src/components/explorer/SubjectPermissionTable.vue
+++ b/loama/src/components/explorer/SubjectPermissionTable.vue
@@ -37,6 +37,12 @@
                     <LoCheck v-if="slotProps.data.permissions?.includes(Permission.Control)" />
                 </template>
             </Column>
+            <Column header="Enabled">
+                <template #body="slotProps">
+                    <ToggleSwitch :modelValue="slotProps.data.isEnabled"
+                        @update:modelValue="e => toggleSubjectAccess(e, slotProps.data.subject)" />
+                </template>
+            </Column>
             <Column header="">
                 <template #body="slotProps">
                     <LoButton :left-icon="PhPencil" @click="() => selectedSubject = slotProps.data">Edit</LoButton>
@@ -92,6 +98,7 @@ import LoSwitch from '../LoSwitch.vue';
 import NewSubject from './NewSubject.vue';
 import { useToast } from 'primevue/usetoast';
 import { useConfirm } from "primevue/useconfirm";
+import ToggleSwitch from 'primevue/toggleswitch';
 
 const ALL_PERMISSIONS: Permission[] = [Permission.Read, Permission.Write, Permission.Append];
 
@@ -153,6 +160,18 @@ const handleSubjectPermissionUpdates = async (newValue: boolean, permission: Per
     } finally {
         updating.value = false;
     }
+}
+
+const toggleSubjectAccess = async (isEnabled: boolean, subject: WebIdSubject | PublicSubject) => {
+    if (!selectedEntry.value) {
+        throw new Error('No selected entry to toggle permissions for');
+    }
+    if (isEnabled) {
+        await activeController.enablePermissions(selectedEntry.value.resourceUrl, subject);
+    } else {
+        await activeController.disablePermissions(selectedEntry.value.resourceUrl, subject);
+    }
+    await refreshEntryPermissions();
 }
 
 const handleSubjectDrawerClose = async () => {


### PR DESCRIPTION
Adds a switch will remove the access of a user.
It preserves the given permissions in the index & will prevent remote from overwriting these when an item is disabled

closes #20 