### PR TITLE
Feat: add access request & granting

### DIFF
--- a/controller/src/classes/AccessRequest.ts
+++ b/controller/src/classes/AccessRequest.ts
@@ -1,4 +1,4 @@
-import { Resources } from "@/types";
+import { ResourceAccessRequestNode, Resources } from "@/types";
 import { IAccessRequest, IStore } from "@/types/modules";
 
 export class AccessRequest implements IAccessRequest {
@@ -6,6 +6,38 @@ export class AccessRequest implements IAccessRequest {
 
     constructor(resources: IStore<Resources>) {
         this.resources = resources;
+    }
+
+    async getRequestableResources(containerUrl: string) {
+        const requestableResources = await this.resources.getCurrent();
+        const filteredRequestableResources = requestableResources.items.filter(item => item.startsWith(containerUrl) && item !== containerUrl);
+        let masterNode: ResourceAccessRequestNode = {
+            resourceUrl: containerUrl,
+            canRequestAccess: requestableResources.items.includes(containerUrl),
+            children: {},
+        };
+
+        filteredRequestableResources.forEach(resource => {
+            const pathParts = resource.replace(containerUrl, "").split('/');
+            pathParts.reduce(function(parentNode, pathPart, index) {
+                if (pathPart == "") {
+                    return parentNode;
+                }
+                if (!parentNode.children) {
+                    parentNode.children = {};
+                }
+                if (parentNode.children[pathPart]) {
+                    parentNode.children[pathPart].canRequestAccess = pathParts.length === index;
+                }
+                return parentNode.children[pathPart] || (parentNode.children[pathPart] = {
+                    resourceUrl: `${parentNode.resourceUrl}${parentNode.resourceUrl.endsWith("/") ? "" : "/"}${pathPart}`,
+                    canRequestAccess: (pathParts.length - 1) === index,
+                    children: {},
+                });
+            }, masterNode)
+        })
+
+        return masterNode;
     }
 
     async canRequestAccessToResource(resourceUrl: string) {

--- a/controller/src/classes/AccessRequest.ts
+++ b/controller/src/classes/AccessRequest.ts
@@ -1,0 +1,36 @@
+import { Resources } from "@/types";
+import { IAccessRequest, IStore } from "@/types/modules";
+
+export class AccessRequest implements IAccessRequest {
+    private resources: IStore<Resources>;
+
+    constructor(resources: IStore<Resources>) {
+        this.resources = resources;
+    }
+
+    async canRequestAccessToResource(resourceUrl: string) {
+        const resources = await this.resources.getCurrent();
+        return resources.items.includes(resourceUrl);
+    }
+
+    async allowAccessRequest(resourceUrl: string) {
+        const resources = await this.resources.getCurrent();
+        if (resources.items.includes(resourceUrl)) {
+            return;
+        }
+        resources.items.push(resourceUrl);
+
+        await this.resources.saveToRemote();
+    }
+
+    async disallowAccessRequest(resourceUrl: string) {
+        const resources = await this.resources.getCurrent();
+        if (!resources.items.includes(resourceUrl)) {
+            return;
+        }
+        const idx = resources.items.indexOf(resourceUrl);
+        resources.items.splice(idx, 1);
+
+        await this.resources.saveToRemote();
+    }
+}

--- a/controller/src/classes/AccessRequest.ts
+++ b/controller/src/classes/AccessRequest.ts
@@ -1,12 +1,14 @@
 import { ResourceAccessRequestNode, Resources } from "@/types";
-import { IAccessRequest, IStore } from "@/types/modules";
+import { IAccessRequest, IStore, IStoreConstructor } from "@/types/modules";
 import { fetch as solidFetch } from '@inrupt/solid-client-authn-browser'
 
 export class AccessRequest implements IAccessRequest {
     private resources: IStore<Resources>;
+    private inbox: IStore<unknown>;
 
-    constructor(resources: IStore<Resources>) {
-        this.resources = resources;
+    constructor(storeConstructor: IStoreConstructor, resourcesStore: IStore<Resources>) {
+        this.resources = resourcesStore;
+        this.inbox = new storeConstructor("public/loama/inbox.ttl", () => ({}));
     }
 
     // Checks if our inbox to retrieve requests exists

--- a/controller/src/classes/AccessRequest.ts
+++ b/controller/src/classes/AccessRequest.ts
@@ -1,16 +1,16 @@
 import { getLinkedResourceUrlAll, getResourceInfo } from "@inrupt/solid-client";
 import { Permission, ResourceAccessRequestNode, Resources } from "../types";
-import { IAccessRequest, IController, IInboxConstructor, IStore } from "../types/modules";
+import { IAccessRequest, IController, IInbox, IInboxConstructor, IStore } from "../types/modules";
 
 export class AccessRequest implements IAccessRequest {
     private resources: IStore<Resources>;
-    private inbox: IStore<unknown[]>;
+    private inbox: IInbox<unknown>;
     private controller: IController<{}>;
 
     constructor(controller: IController<{}>, inboxConstructor: IInboxConstructor, resourcesStore: IStore<Resources>) {
         this.controller = controller;
         this.resources = resourcesStore;
-        this.inbox = new inboxConstructor("public/loama/inbox/") as IStore<unknown[]>;
+        this.inbox = new inboxConstructor("public/loama/inbox/") as IInbox<unknown>;
     }
 
     async setPodUrl(url: string) {

--- a/controller/src/classes/AccessRequest.ts
+++ b/controller/src/classes/AccessRequest.ts
@@ -1,5 +1,5 @@
 import { getLinkedResourceUrlAll, getResourceInfo } from "@inrupt/solid-client";
-import { Permission, ResourceAccessRequestNode, Resources } from "../types";
+import { AccessRequestMessage, Permission, ResourceAccessRequestNode, Resources } from "../types";
 import { IAccessRequest, IController, IInbox, IInboxConstructor, IStore } from "../types/modules";
 
 export class AccessRequest implements IAccessRequest {
@@ -136,5 +136,14 @@ export class AccessRequest implements IAccessRequest {
         const inbox = await this.inbox.getCurrent();
         inbox.push(...messages);
         await this.inbox.saveToRemote();
+    }
+
+    async loadAccessRequests() {
+        const messages = await this.inbox.getMessages();
+        return messages as AccessRequestMessage[];
+    }
+
+    async removeRequest(messageUrl: string) {
+
     }
 }

--- a/controller/src/classes/AccessRequest.ts
+++ b/controller/src/classes/AccessRequest.ts
@@ -15,8 +15,9 @@ export class AccessRequest implements IAccessRequest {
 
     async setPodUrl(url: string) {
         this.inbox.setPodUrl(url)
-        // This will make sure we have the inbox created in our own container
+        // This will make sure we have the inbox & resources.json created in our own container
         await this.inbox.getOrCreate();
+        await this.resources.getOrCreate();
 
         const publicController = this.controller.isSubjectSupported({ type: "public" });
 

--- a/controller/src/classes/AccessRequest.ts
+++ b/controller/src/classes/AccessRequest.ts
@@ -89,8 +89,11 @@ export class AccessRequest implements IAccessRequest {
     }
 
     async sendRequestNotification(originWebId: string, resources: string[]) {
+        const requestableResources = await this.resources.getCurrent();
+        const filteredResources = resources.filter(r => requestableResources.items.includes(r));
+
         const messages: unknown[] = [];
-        for (let r of resources) {
+        for (let r of filteredResources) {
             // TODO: Replace with our own calls instead of using the inrupt SDK
             const resourceInfo = await getResourceInfo(r, {
                 ignoreAuthenticationErrors: true,

--- a/controller/src/classes/AccessRequest.ts
+++ b/controller/src/classes/AccessRequest.ts
@@ -43,6 +43,9 @@ export class AccessRequest implements IAccessRequest {
             const pathParts = resource.replace(containerUrl, "").split('/');
             pathParts.reduce(function(parentNode, pathPart, index) {
                 if (pathPart == "") {
+                    // Requestable is a directory, which ends in "/"
+                    parentNode.resourceUrl += "/";
+                    parentNode.canRequestAccess = true;
                     return parentNode;
                 }
                 if (!parentNode.children) {

--- a/controller/src/classes/Controller.ts
+++ b/controller/src/classes/Controller.ts
@@ -6,7 +6,7 @@ import { Mutex } from "./utils/Mutex";
 export class Controller<T extends Record<keyof T, BaseSubject<keyof T & string>>> extends Mutex implements IController<T> {
     private index: IStore<Index<T[keyof T & string]>>
     private resources: IStore<Resources>
-    private accessRequest: IAccessRequest;
+    private accessRequest: AccessRequest;
     private subjectConfigs: SubjectConfigs<T>
 
     constructor(indexStore: IStore<Index<T[keyof T & string]>>, resourcesStore: IStore<Resources>, subjects: SubjectConfigs<T>) {
@@ -93,6 +93,7 @@ export class Controller<T extends Record<keyof T, BaseSubject<keyof T & string>>
     setPodUrl(podUrl: string) {
         this.index.setPodUrl(podUrl);
         this.resources.setPodUrl(podUrl);
+        this.accessRequest.validateInboxExistence()
     }
 
     unsetPodUrl() {

--- a/controller/src/classes/Controller.ts
+++ b/controller/src/classes/Controller.ts
@@ -93,10 +93,10 @@ export class Controller<T extends Record<keyof T, BaseSubject<keyof T & string>>
         return this.accessRequest;
     }
 
-    setPodUrl(podUrl: string) {
+    async setPodUrl(podUrl: string) {
         this.index.setPodUrl(podUrl);
         this.resources.setPodUrl(podUrl);
-        this.accessRequest.setPodUrl(podUrl)
+        await this.accessRequest.setPodUrl(podUrl)
     }
 
     unsetPodUrl() {

--- a/controller/src/classes/Controller.ts
+++ b/controller/src/classes/Controller.ts
@@ -1,5 +1,5 @@
 import { BaseSubject, Index, IndexItem, Permission, ResourcePermissions, Resources, SubjectPermissions } from "../types";
-import { IAccessRequest, IController, IStore, SubjectConfig, SubjectConfigs, SubjectKey, SubjectType } from "../types/modules";
+import { IAccessRequest, IController, IStore, IStoreConstructor, SubjectConfig, SubjectConfigs, SubjectKey, SubjectType } from "../types/modules";
 import { AccessRequest } from "./AccessRequest";
 import { Mutex } from "./utils/Mutex";
 
@@ -9,11 +9,12 @@ export class Controller<T extends Record<keyof T, BaseSubject<keyof T & string>>
     private accessRequest: AccessRequest;
     private subjectConfigs: SubjectConfigs<T>
 
-    constructor(indexStore: IStore<Index<T[keyof T & string]>>, resourcesStore: IStore<Resources>, subjects: SubjectConfigs<T>) {
+    constructor(storeConstructor: IStoreConstructor, subjects: SubjectConfigs<T>) {
         super();
-        this.index = indexStore;
-        this.resources = resourcesStore;
-        this.accessRequest = new AccessRequest(resourcesStore);
+        // There is currently no "easy" solution to get around the as IStore...
+        this.index = new storeConstructor("index.json", () => ({ id: "", items: [] })) as IStore<Index<T[keyof T & string]>>;
+        this.resources = new storeConstructor("resources.json", () => ({ id: "", items: [] })) as IStore<Resources>;;
+        this.accessRequest = new AccessRequest(storeConstructor, this.resources);
         this.subjectConfigs = subjects;
     }
 

--- a/controller/src/classes/Controller.ts
+++ b/controller/src/classes/Controller.ts
@@ -1,6 +1,7 @@
 import { BaseSubject, Index, IndexItem, Permission, ResourcePermissions, Resources, SubjectPermissions } from "../types";
 import { IAccessRequest, IController, IInboxConstructor, IStore, IStoreConstructor, SubjectConfig, SubjectConfigs, SubjectKey, SubjectType } from "../types/modules";
-import { AccessRequest } from "./AccessRequest";
+import { AccessRequest } from "./accessRequests/AccessRequest";
+import { InruptAccessRequest } from "./accessRequests/InruptAccessRequest";
 import { Mutex } from "./utils/Mutex";
 
 export class Controller<T extends Record<keyof T, BaseSubject<keyof T & string>>> extends Mutex implements IController<T> {
@@ -15,7 +16,7 @@ export class Controller<T extends Record<keyof T, BaseSubject<keyof T & string>>
         // There is currently no "easy" solution to get around the as IStore...
         this.index = new storeConstructor("index.json", () => ({ id: "", items: [] })) as IStore<Index<T[keyof T & string]>>;
         this.resources = new storeConstructor("resources.json", () => ({ id: "", items: [] })) as IStore<Resources>;;
-        this.accessRequest = new AccessRequest(this as unknown as Controller<{}>, inboxConstructor, this.resources);
+        this.accessRequest = new InruptAccessRequest(this as unknown as Controller<{}>, inboxConstructor, this.resources);
         this.subjectConfigs = subjects;
     }
 

--- a/controller/src/classes/Controller.ts
+++ b/controller/src/classes/Controller.ts
@@ -306,4 +306,25 @@ export class Controller<T extends Record<keyof T, BaseSubject<keyof T & string>>
             }, permissionsPerSubject)
         }
     }
+
+    async allowAccessRequest(resourceUrl: string) {
+        const resources = await this.store.getCurrentResources();
+        if (resources.items.includes(resourceUrl)) {
+            return;
+        }
+        resources.items.push(resourceUrl);
+
+        await this.store.saveToRemoteResources();
+    }
+
+    async denyAccessRequest(resourceUrl: string) {
+        const resources = await this.store.getCurrentResources();
+        if (!resources.items.includes(resourceUrl)) {
+            return;
+        }
+        const idx = resources.items.indexOf(resourceUrl);
+        resources.items.splice(idx, 1);
+
+        await this.store.saveToRemoteResources();
+    }
 }

--- a/controller/src/classes/Controller.ts
+++ b/controller/src/classes/Controller.ts
@@ -210,7 +210,7 @@ export class Controller<T extends Record<keyof T, BaseSubject<keyof T & string>>
     async getContainerPermissionList(containerUrl: string): Promise<ResourcePermissions<T[keyof T]>[]> {
         const configs: SubjectConfig<T>[] = Object.values(this.subjectConfigs);
 
-        const index = await this.index.getCurrentIndex();
+        const index = await this.index.getCurrent();
         const resourcesToSkip = index.items.filter(i => {
             if (!i.resource.includes(containerUrl)) {
                 return false;
@@ -263,7 +263,7 @@ export class Controller<T extends Record<keyof T, BaseSubject<keyof T & string>>
             }
         }));
 
-        await this.index.saveToRemoteIndex();
+        await this.index.saveToRemote();
 
         return await index.items.reduce<Promise<ResourcePermissions<T[keyof T]>[]>>(async (arr, v) => {
             const resourcePath = v.resource.replace(containerUrl, "");

--- a/controller/src/classes/Controller.ts
+++ b/controller/src/classes/Controller.ts
@@ -94,12 +94,13 @@ export class Controller<T extends Record<keyof T, BaseSubject<keyof T & string>>
     setPodUrl(podUrl: string) {
         this.index.setPodUrl(podUrl);
         this.resources.setPodUrl(podUrl);
-        this.accessRequest.validateInboxExistence()
+        this.accessRequest.setPodUrl(podUrl)
     }
 
     unsetPodUrl() {
         this.index.unsetPodUrl();
         this.resources.unsetPodUrl();
+        this.accessRequest.unsetPodUrl();
     }
 
     async getOrCreateIndex() {

--- a/controller/src/classes/accessRequests/AccessRequest.ts
+++ b/controller/src/classes/accessRequests/AccessRequest.ts
@@ -2,6 +2,7 @@ import { getDatetime, getLinkedResourceUrlAll, getResourceInfo, getStringNoLocal
 import { AccessRequestMessage, Permission, RequestResponseMessage, ResourceAccessRequestNode, Resources } from "../../types";
 import { IAccessRequest, IController, IInbox, IInboxConstructor, IStore } from "../../types/modules";
 import { cacheBustedFetch } from "../../util";
+import { PermissionToACL } from "../utils/Permissions";
 
 const REQUEST_RESPONSE_TYPES = ["as:Accept", "as:Reject"]
 
@@ -94,7 +95,7 @@ export abstract class AccessRequest implements IAccessRequest {
         await this.resources.saveToRemote();
     }
 
-    async sendRequestNotification(originWebId: string, resources: string[]) {
+    async sendRequestNotification(originWebId: string, resources: string[], permissions: Permission[]) {
         const requestableResources = await this.resources.getCurrent();
         const filteredResources = resources.filter(r => requestableResources.items.includes(r));
 
@@ -128,11 +129,7 @@ export abstract class AccessRequest implements IAccessRequest {
                     "@type": "acl:Authorization",
                     "acl:agent": originWebId,
                     "acl:accessTo": r,
-                    "acl:mode": [
-                        {
-                            "@id": "acl:Read"
-                        }
-                    ]
+                    "acl:mode": permissions.map(p => ({ "@id": PermissionToACL(p) }))
                 }
             });
         };

--- a/controller/src/classes/accessRequests/AccessRequest.ts
+++ b/controller/src/classes/accessRequests/AccessRequest.ts
@@ -26,7 +26,7 @@ export abstract class AccessRequest implements IAccessRequest {
 
         // Set permissions for info resources
         await publicController.addPermission(this.resources.getDataUrl(), Permission.Read, { type: "public" });
-        await publicController.addPermission(this.inbox.getDataUrl(), Permission.Write, { type: "public" });
+        await publicController.addPermission(this.inbox.getDataUrl(), Permission.Append, { type: "public" });
     }
 
     unsetPodUrl() {

--- a/controller/src/classes/accessRequests/AccessRequest.ts
+++ b/controller/src/classes/accessRequests/AccessRequest.ts
@@ -140,7 +140,7 @@ export abstract class AccessRequest implements IAccessRequest {
         await this.inbox.saveToRemote();
     }
 
-    async sendResponseNotification(type: "accept" | "reject", affectedResource: string) {
+    async sendResponseNotification(type: "accept" | "reject", message: AccessRequestMessage) {
         const inbox = await this.inbox.getCurrent();
         inbox.push({
             "@context": {
@@ -148,8 +148,14 @@ export abstract class AccessRequest implements IAccessRequest {
             },
             "@type": type == "accept" ? "as:Accept" : "as:Reject",
             "@id": `urn:loama:${crypto.randomUUID()}`,
-            "as:object": this.inbox.getDataUrl(),
-            "as:target": affectedResource,
+            "as:actor": this.inbox.getDataUrl(),
+            "as:object": {
+                "@id": `urn:loama:${crypto.randomUUID()}`,
+                "@type": "acl:Authorization",
+                "acl:agent": message.actor,
+                "acl:accessTo": message.target,
+                "acl:mode": message.permissions.map(p => ({ "@id": p }))
+            }
         });
         await this.inbox.saveToRemote();
     }

--- a/controller/src/classes/accessRequests/InruptAccessRequest.ts
+++ b/controller/src/classes/accessRequests/InruptAccessRequest.ts
@@ -1,0 +1,19 @@
+import { IAccessRequest, IController, IInboxConstructor, IStore } from "@/types/modules";
+import { AccessRequest } from "./AccessRequest";
+import { Resources } from "@/types";
+import { getDefaultSession } from "@inrupt/solid-client-authn-browser";
+import { deleteFile } from "@inrupt/solid-client";
+
+export class InruptAccessRequest extends AccessRequest implements IAccessRequest {
+    constructor(controller: IController<{}>, inboxConstructor: IInboxConstructor, resourcesStore: IStore<Resources>) {
+        super(controller, inboxConstructor, resourcesStore)
+    }
+
+    async removeRequest(messageUrl: string) {
+        const session = getDefaultSession();
+
+        deleteFile(messageUrl, {
+            fetch: session.fetch
+        })
+    }
+}

--- a/controller/src/classes/accessRequests/InruptAccessRequest.ts
+++ b/controller/src/classes/accessRequests/InruptAccessRequest.ts
@@ -12,7 +12,7 @@ export class InruptAccessRequest extends AccessRequest implements IAccessRequest
     async removeRequest(messageUrl: string) {
         const session = getDefaultSession();
 
-        deleteFile(messageUrl, {
+        await deleteFile(messageUrl, {
             fetch: session.fetch
         })
     }

--- a/controller/src/classes/permissionManager/inrupt/GroupManager.ts
+++ b/controller/src/classes/permissionManager/inrupt/GroupManager.ts
@@ -4,14 +4,14 @@ import { IPermissionManager, SubjectKey } from "../../../types/modules";
 import { InruptPermissionManager } from "./InruptPermissionManager";
 import { getDefaultSession } from "@inrupt/solid-client-authn-browser";
 import { setAgentAccess } from "@inrupt/solid-client/universal";
-import { cacheBustedFetch } from "../../../util";
+import { cacheBustedSessionFetch } from "../../../util";
 
 export class GroupManager<T extends Record<keyof T, BaseSubject<keyof T & string>>> extends InruptPermissionManager<T> implements IPermissionManager<T> {
     // This is a replacement for https://github.com/inrupt/solid-client-js/blob/eb8e86f61458ec76fa2244f7b38b7d7983bbd810/src/access/wac.ts#L262 because it is not exposed in the inrupt library
     private async getGroupAccessAll(resource: string): Promise<Record<string, Access> | null> {
         const session = getDefaultSession();
         const resourceInfo = await getResourceInfoWithAcl(resource, {
-            fetch: cacheBustedFetch(session),
+            fetch: cacheBustedSessionFetch(session),
         });
         return getGroupAccessAll(resourceInfo)
     }

--- a/controller/src/classes/permissionManager/inrupt/InruptPermissionManager.ts
+++ b/controller/src/classes/permissionManager/inrupt/InruptPermissionManager.ts
@@ -87,11 +87,15 @@ export abstract class InruptPermissionManager<T extends Record<keyof T, BaseSubj
                     if (resourceToSkip.includes(resource.url)) {
                         return {
                             resourceUrl: resource.url,
+                            // We can set this to false as this is the default & getting doubled checked in the controller
+                            canRequestAccess: false,
                             permissionsPerSubject: [],
                         }
                     }
                     return {
                         resourceUrl: resource.url,
+                        // We can set this to false as this is the default & getting doubled checked in the controller
+                        canRequestAccess: false,
                         permissionsPerSubject: await this.getRemotePermissions(resource.url)
                     }
                 })

--- a/controller/src/classes/permissionManager/inrupt/PublicManager.ts
+++ b/controller/src/classes/permissionManager/inrupt/PublicManager.ts
@@ -4,7 +4,7 @@ import { IPermissionManager, SubjectKey } from "../../../types/modules";
 import { InruptPermissionManager } from "./InruptPermissionManager";
 import { getDefaultSession } from "@inrupt/solid-client-authn-browser";
 import { getPublicAccess, setPublicAccess } from "@inrupt/solid-client/universal";
-import { cacheBustedFetch } from "../../../util";
+import { cacheBustedSessionFetch } from "../../../util";
 
 export class PublicManager<T extends Record<keyof T, BaseSubject<keyof T & string>>> extends InruptPermissionManager<T> implements IPermissionManager<T> {
 
@@ -32,7 +32,7 @@ export class PublicManager<T extends Record<keyof T, BaseSubject<keyof T & strin
 
     async getRemotePermissions<K extends SubjectKey<T>>(resourceUrl: string) {
         const session = getDefaultSession();
-        const publicAccess = await getPublicAccess(resourceUrl, { fetch: cacheBustedFetch(session) })
+        const publicAccess = await getPublicAccess(resourceUrl, { fetch: cacheBustedSessionFetch(session) })
 
         if (!publicAccess) {
             return [];

--- a/controller/src/classes/permissionManager/inrupt/WebIdManager.ts
+++ b/controller/src/classes/permissionManager/inrupt/WebIdManager.ts
@@ -4,7 +4,7 @@ import { IPermissionManager, SubjectKey } from "../../../types/modules";
 import { InruptPermissionManager } from "./InruptPermissionManager";
 import { getAgentAccessAll, setAgentAccess } from "@inrupt/solid-client/universal";
 import { AccessModes, } from "@inrupt/solid-client";
-import { cacheBustedFetch } from "../../../util";
+import { cacheBustedSessionFetch } from "../../../util";
 
 export class WebIdManager<T extends Record<keyof T, BaseSubject<keyof T & string>>> extends InruptPermissionManager<T> implements IPermissionManager<T> {
     private async updateACL<K extends SubjectKey<T>>(resource: string, subject: T[K], accessModes: Partial<AccessModes>) {
@@ -33,7 +33,7 @@ export class WebIdManager<T extends Record<keyof T, BaseSubject<keyof T & string
 
     async getRemotePermissions<K extends SubjectKey<T>>(resourceUrl: string) {
         const session = getDefaultSession();
-        const agentAccess = await getAgentAccessAll(resourceUrl, { fetch: cacheBustedFetch(session) });
+        const agentAccess = await getAgentAccessAll(resourceUrl, { fetch: cacheBustedSessionFetch(session) });
 
         if (!agentAccess) {
             return [];

--- a/controller/src/classes/stores/BaseStore.ts
+++ b/controller/src/classes/stores/BaseStore.ts
@@ -1,10 +1,11 @@
-import { SubjectKey } from "@/types/modules";
-import { BaseSubject, Index, Resources } from "../../types";
-
-export abstract class BaseStore<T extends Record<keyof T, BaseSubject<keyof T & string>>> {
+export abstract class BaseStore<T> {
     protected podUrl?: string = undefined;
-    protected index?: Index<T[keyof T]> = undefined;
-    protected resources?: Resources = undefined;
+    protected filePath: string;
+    protected data?: T = undefined;
+
+    constructor(filePath: string) {
+        this.filePath = filePath
+    }
 
     setPodUrl(url: string): void {
         this.podUrl = url;
@@ -14,21 +15,12 @@ export abstract class BaseStore<T extends Record<keyof T, BaseSubject<keyof T & 
         this.podUrl = undefined;
     }
 
-    abstract getOrCreateResources(): Promise<Resources>;
+    abstract getOrCreate(): Promise<T>;
 
-    async getCurrentResources() {
-        if (!this.resources) {
-            this.resources = await this.getOrCreateResources();
+    async getCurrent() {
+        if (!this.data) {
+            this.data = await this.getOrCreate();
         }
-        return this.resources as Resources;
-    }
-
-    abstract getOrCreateIndex(): Promise<Index<T[keyof T]>>;
-
-    async getCurrentIndex<K extends SubjectKey<T>>() {
-        if (!this.index) {
-            this.index = await this.getOrCreateIndex();
-        }
-        return this.index as Index<T[K]>;
+        return this.data;
     }
 }

--- a/controller/src/classes/stores/BaseStore.ts
+++ b/controller/src/classes/stores/BaseStore.ts
@@ -1,9 +1,10 @@
 import { SubjectKey } from "@/types/modules";
-import { BaseSubject, Index } from "../../types";
+import { BaseSubject, Index, Resources } from "../../types";
 
 export abstract class BaseStore<T extends Record<keyof T, BaseSubject<keyof T & string>>> {
     protected podUrl?: string = undefined;
     protected index?: Index<T[keyof T]> = undefined;
+    protected resources?: Resources = undefined;
 
     setPodUrl(url: string): void {
         this.podUrl = url;
@@ -11,6 +12,15 @@ export abstract class BaseStore<T extends Record<keyof T, BaseSubject<keyof T & 
 
     unsetPodUrl(): void {
         this.podUrl = undefined;
+    }
+
+    abstract getOrCreateResources(): Promise<Resources>;
+
+    async getCurrentResources() {
+        if (!this.resources) {
+            this.resources = await this.getOrCreateResources();
+        }
+        return this.resources as Resources;
     }
 
     abstract getOrCreateIndex(): Promise<Index<T[keyof T]>>;

--- a/controller/src/classes/stores/BaseStore.ts
+++ b/controller/src/classes/stores/BaseStore.ts
@@ -15,6 +15,10 @@ export abstract class BaseStore<T> {
         this.podUrl = undefined;
     }
 
+    getPodUrl() {
+        return this.podUrl
+    }
+
     abstract getOrCreate(): Promise<T>;
 
     async getCurrent() {

--- a/controller/src/classes/stores/BaseStore.ts
+++ b/controller/src/classes/stores/BaseStore.ts
@@ -9,6 +9,9 @@ export abstract class BaseStore<T> {
 
     setPodUrl(url: string): void {
         this.podUrl = url;
+        if (!this.podUrl.endsWith("/")) {
+            this.podUrl += "/";
+        }
     }
 
     unsetPodUrl(): void {

--- a/controller/src/classes/stores/BaseStore.ts
+++ b/controller/src/classes/stores/BaseStore.ts
@@ -19,6 +19,10 @@ export abstract class BaseStore<T> {
         return this.podUrl
     }
 
+    getDataUrl() {
+        return `${this.podUrl}${this.filePath}`
+    }
+
     abstract getOrCreate(): Promise<T>;
 
     async getCurrent() {

--- a/controller/src/classes/stores/InruptInboxStore.ts
+++ b/controller/src/classes/stores/InruptInboxStore.ts
@@ -1,10 +1,10 @@
-import { IStore } from "@/types/modules";
-import { createContainerAt, FetchError, getResourceInfo, isContainer } from "@inrupt/solid-client";
+import { IInbox } from "@/types/modules";
+import { createContainerAt, FetchError, getContainedResourceUrlAll, getDatetime, getResourceInfo, getSolidDataset, getStringNoLocale, getThingAll, getUrl, isContainer } from "@inrupt/solid-client";
 import { BaseStore } from "./BaseStore";
 import { getDefaultSession, Session } from "@inrupt/solid-client-authn-browser";
 
 // A modified store which does not retrieve the data from the server and only does append actions
-export class InruptInboxStore<M, T extends M[] = M[]> extends BaseStore<T> implements IStore<T> {
+export class InruptInboxStore<M> extends BaseStore<M[]> implements IInbox<M> {
     protected session: Session;
 
     constructor(filePath: string) {
@@ -12,7 +12,7 @@ export class InruptInboxStore<M, T extends M[] = M[]> extends BaseStore<T> imple
         this.session = getDefaultSession()
     }
 
-    override async getOrCreate(): Promise<T> {
+    override async getOrCreate() {
         try {
             let inboxResourceInfo = await getResourceInfo(this.getDataUrl(), { fetch: this.session.fetch });
             if (!isContainer(inboxResourceInfo)) {
@@ -28,7 +28,7 @@ export class InruptInboxStore<M, T extends M[] = M[]> extends BaseStore<T> imple
             }
             console.error(error);
         } finally {
-            return this.data ??= [] as unknown as T;
+            return this.data ??= [] as unknown as M[];
         }
     }
 
@@ -51,6 +51,44 @@ export class InruptInboxStore<M, T extends M[] = M[]> extends BaseStore<T> imple
             })
         }
 
-        this.data = [] as unknown as T
+        this.data = [] as unknown as M[]
+    }
+
+    async getMessages() {
+        const inboxDataSet = await getSolidDataset(this.getDataUrl(), { fetch: this.session.fetch });
+        const messageUrls = getContainedResourceUrlAll(inboxDataSet);
+        const messages: unknown[] = [];
+        for (let url of messageUrls) {
+            const message = await getSolidDataset(url, { fetch: this.session.fetch });
+            const allThings = getThingAll(message)
+            const appendRequest = allThings.filter(t => t.predicates["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"].namedNodes?.includes("tbd:AppendRequest"))?.[0];
+
+            // This message does not contain a tbd:AppendRequest
+            if (!appendRequest) {
+                continue
+            }
+
+            const authorizationUrl = getUrl(appendRequest, "as:object");
+            if (!authorizationUrl) {
+                throw new Error(`Message with id ${url} does has no reference to an authorization object`);
+            }
+
+            const authorizationThing = allThings.filter(t => t.url === authorizationUrl)?.[0];
+            if (!authorizationThing) {
+                throw new Error(`Message with id ${url} does not contain the referenced authorization object`);
+            }
+            console.log(authorizationThing);
+
+            const entry = {
+                id: appendRequest.url,
+                actor: getStringNoLocale(appendRequest, "as:actor"),
+                requestedAt: getDatetime(appendRequest, "as:published"),
+                target: getStringNoLocale(authorizationThing, "acl:accessTo"),
+                permissions: authorizationThing.predicates["acl:mode"].namedNodes,
+            }
+            console.log(appendRequest, entry);
+            messages.push(entry);
+        }
+        return []
     }
 }

--- a/controller/src/classes/stores/InruptInboxStore.ts
+++ b/controller/src/classes/stores/InruptInboxStore.ts
@@ -1,0 +1,56 @@
+import { IStore } from "@/types/modules";
+import { createContainerAt, FetchError, getResourceInfo, isContainer } from "@inrupt/solid-client";
+import { BaseStore } from "./BaseStore";
+import { getDefaultSession, Session } from "@inrupt/solid-client-authn-browser";
+
+// A modified store which does not retrieve the data from the server and only does append actions
+export class InruptInboxStore<M, T extends M[] = M[]> extends BaseStore<T> implements IStore<T> {
+    protected session: Session;
+
+    constructor(filePath: string) {
+        super(filePath);
+        this.session = getDefaultSession()
+    }
+
+    override async getOrCreate(): Promise<T> {
+        try {
+            let inboxResourceInfo = await getResourceInfo(this.getDataUrl(), { fetch: this.session.fetch });
+            if (!isContainer(inboxResourceInfo)) {
+                throw new Error("Inbox is not a container");
+            }
+        } catch (error: unknown) {
+            // TODO: check if we can add a new inbox link to the loama container in a more generic way
+            if (error instanceof FetchError && error.statusCode === 404) {
+                await createContainerAt(this.getDataUrl(), { fetch: this.session.fetch });
+            }
+            if (error instanceof Error && error.message === "Inbox is not a container") {
+                await createContainerAt(this.getDataUrl(), { fetch: this.session.fetch });
+            }
+            console.error(error);
+        } finally {
+            return this.data ??= [] as unknown as T;
+        }
+    }
+
+    async saveToRemote() {
+        if (!this.data) {
+            await this.getOrCreate();
+        }
+        if (!this.data) {
+            throw new Error(`Store data(${this.filePath}) not found or invalid`);
+        }
+
+        // Write each message to a new file in the inbox
+        for (let msg of this.data) {
+            await fetch(this.getDataUrl(), {
+                method: "POST",
+                headers: {
+                    "Content-Type": 'application/ld+json;profile="https://www.w3.org/ns/activitystreams"'
+                },
+                body: JSON.stringify(msg)
+            })
+        }
+
+        this.data = [] as unknown as T
+    }
+}

--- a/controller/src/classes/stores/InruptInboxStore.ts
+++ b/controller/src/classes/stores/InruptInboxStore.ts
@@ -79,7 +79,7 @@ export class InruptInboxStore<M> extends BaseStore<M[]> implements IInbox<M> {
             }
 
             const entry = {
-                id: appendRequest.url,
+                id: url,
                 actor: getStringNoLocale(appendRequest, "as:actor"),
                 requestedAt: getDatetime(appendRequest, "as:published"),
                 target: getStringNoLocale(authorizationThing, "acl:accessTo"),

--- a/controller/src/classes/stores/InruptInboxStore.ts
+++ b/controller/src/classes/stores/InruptInboxStore.ts
@@ -77,7 +77,6 @@ export class InruptInboxStore<M> extends BaseStore<M[]> implements IInbox<M> {
             if (!authorizationThing) {
                 throw new Error(`Message with id ${url} does not contain the referenced authorization object`);
             }
-            console.log(authorizationThing);
 
             const entry = {
                 id: appendRequest.url,
@@ -86,9 +85,8 @@ export class InruptInboxStore<M> extends BaseStore<M[]> implements IInbox<M> {
                 target: getStringNoLocale(authorizationThing, "acl:accessTo"),
                 permissions: authorizationThing.predicates["acl:mode"].namedNodes,
             }
-            console.log(appendRequest, entry);
             messages.push(entry);
         }
-        return []
+        return messages;
     }
 }

--- a/controller/src/classes/stores/InruptStore.ts
+++ b/controller/src/classes/stores/InruptStore.ts
@@ -1,8 +1,9 @@
 import { FetchError, getFile, overwriteFile, saveFileInContainer, WithResourceInfo } from "@inrupt/solid-client";
-import { BaseSubject, Index } from "../../types";
+import { BaseSubject, Index, Resources } from "../../types";
 import { IStore } from "../../types/modules";
 import { BaseStore } from "./BaseStore";
 import { getDefaultSession, Session } from "@inrupt/solid-client-authn-browser";
+import { setPublicAccess } from "@inrupt/solid-client/universal";
 
 /**
  * A store implementation using the inrupt sdk to actually communicate with the pod
@@ -12,6 +13,7 @@ import { getDefaultSession, Session } from "@inrupt/solid-client-authn-browser";
 export class InruptStore<T extends Record<keyof T, BaseSubject<keyof T & string>>> extends BaseStore<T> implements IStore<T> {
     // TODO this should be a more resilient path: be.ugent.idlab.knows.solid.loama.index.js or smth
     private indexPath = "index.json";
+    private resourcesPath = "resources.json";
     private session: Session;
 
     constructor() {
@@ -19,10 +21,44 @@ export class InruptStore<T extends Record<keyof T, BaseSubject<keyof T & string>
         this.session = getDefaultSession()
     }
 
-    private indexToIndexFile(): File {
-        return new File([JSON.stringify(this.index)], this.indexPath, {
+    private toJsonFile(data: unknown, path: string): File {
+        return new File([JSON.stringify(data)], path, {
             type: "application/json",
         });
+    }
+
+    async getOrCreateResources(): Promise<Resources> {
+        if (!this.podUrl) {
+            throw new Error("Cannot get current resources file: pod location is not set");
+        }
+
+        if (this.resources) {
+            return this.resources;
+        }
+
+        const resourcesPath = `${this.podUrl}${this.resourcesPath}`;
+        let file: (Blob & WithResourceInfo) | undefined = undefined
+        try {
+            file = await getFile(resourcesPath, { fetch: this.session.fetch })
+        } catch (error: unknown) {
+            if (error instanceof FetchError && error.statusCode === 404) {
+                this.resources = { id: resourcesPath, items: [] }
+                file = await saveFileInContainer(
+                    this.podUrl,
+                    this.toJsonFile(this.resources, this.resourcesPath),
+                    { fetch: this.session.fetch }
+                );
+                await setPublicAccess(resourcesPath, { read: true }, { fetch: this.session.fetch });
+            }
+        }
+
+        const fileText = await file?.text();
+        this.resources = JSON.parse(fileText ?? "{}");
+        if (!this.resources) {
+            throw new Error("Resources not found or invalid");
+        }
+
+        return this.resources;
     }
 
     // NOTE: Possible will move the podUrl to the parameters, this works for the current POC
@@ -44,7 +80,7 @@ export class InruptStore<T extends Record<keyof T, BaseSubject<keyof T & string>
                 this.index = { id: indexUrl, items: [] }
                 file = await saveFileInContainer(
                     this.podUrl,
-                    this.indexToIndexFile(),
+                    this.toJsonFile(this.index, this.indexPath),
                     { fetch: this.session.fetch }
                 );
             }
@@ -67,7 +103,20 @@ export class InruptStore<T extends Record<keyof T, BaseSubject<keyof T & string>
             throw new Error("Index not found or invalid");
         }
 
-        overwriteFile(this.index.id, this.indexToIndexFile(), {
+        overwriteFile(this.index.id, this.toJsonFile(this.index, this.indexPath), {
+            fetch: this.session.fetch,
+        });
+    }
+
+    async saveToRemoteResources() {
+        if (!this.resources) {
+            await this.getOrCreateResources();
+        }
+        if (!this.resources) {
+            throw new Error("Resources not found or invalid");
+        }
+
+        overwriteFile(this.resources.id, this.toJsonFile(this.resources, this.resourcesPath), {
             fetch: this.session.fetch,
         });
     }

--- a/controller/src/classes/utils/Permissions.ts
+++ b/controller/src/classes/utils/Permissions.ts
@@ -1,0 +1,16 @@
+import { Permission } from "../../types";
+
+export const PermissionToACL = (permission: Permission): string => {
+    switch (permission) {
+        case Permission.Read:
+            return "acl:Read"
+        case Permission.Write:
+            return "acl:Write"
+        case Permission.Append:
+            return "acl:Append"
+        case Permission.Control:
+            return "acl:Control"
+        default:
+            throw new Error("Permission not found");
+    }
+}

--- a/controller/src/controllers.ts
+++ b/controller/src/controllers.ts
@@ -22,3 +22,22 @@ export const activeController = new Controller<{
         },
     },
 )
+
+export const createBasicController = () => {
+    return new Controller<{
+        webId: WebIdSubject,
+        public: PublicSubject,
+    }>(
+        new InruptStore(),
+        {
+            webId: {
+                resolver: new WebIdResolver(),
+                manager: new WebIdManager()
+            },
+            public: {
+                resolver: new PublicResolver(),
+                manager: new PublicManager(),
+            },
+        },
+    )
+}

--- a/controller/src/controllers.ts
+++ b/controller/src/controllers.ts
@@ -1,3 +1,4 @@
+import { AccessRequest } from "./classes/AccessRequest";
 import { Controller } from "./classes/Controller";
 import { PublicManager } from "./classes/permissionManager/inrupt/PublicManager";
 import { WebIdManager } from "./classes/permissionManager/inrupt/WebIdManager";
@@ -10,7 +11,8 @@ export const activeController = new Controller<{
     webId: WebIdSubject,
     public: PublicSubject,
 }>(
-    new InruptStore(),
+    new InruptStore("index.json", () => ({ id: "", items: [] })),
+    new AccessRequest(new InruptStore("resources.json", () => ({ id: "", items: [] }))),
     {
         webId: {
             resolver: new WebIdResolver(),
@@ -28,7 +30,8 @@ export const createBasicController = () => {
         webId: WebIdSubject,
         public: PublicSubject,
     }>(
-        new InruptStore(),
+        new InruptStore("index.json", () => ({ id: "", items: [] })),
+        new AccessRequest(new InruptStore("resources.json", () => ({ id: "", items: [] }))),
         {
             webId: {
                 resolver: new WebIdResolver(),

--- a/controller/src/controllers.ts
+++ b/controller/src/controllers.ts
@@ -12,7 +12,7 @@ export const activeController = new Controller<{
     public: PublicSubject,
 }>(
     new InruptStore("index.json", () => ({ id: "", items: [] })),
-    new AccessRequest(new InruptStore("resources.json", () => ({ id: "", items: [] }))),
+    new InruptStore("resources.json", () => ({ id: "", items: [] })),
     {
         webId: {
             resolver: new WebIdResolver(),
@@ -31,7 +31,7 @@ export const createBasicController = () => {
         public: PublicSubject,
     }>(
         new InruptStore("index.json", () => ({ id: "", items: [] })),
-        new AccessRequest(new InruptStore("resources.json", () => ({ id: "", items: [] }))),
+        new InruptStore("resources.json", () => ({ id: "", items: [] })),
         {
             webId: {
                 resolver: new WebIdResolver(),

--- a/controller/src/controllers.ts
+++ b/controller/src/controllers.ts
@@ -1,4 +1,3 @@
-import { AccessRequest } from "./classes/AccessRequest";
 import { Controller } from "./classes/Controller";
 import { PublicManager } from "./classes/permissionManager/inrupt/PublicManager";
 import { WebIdManager } from "./classes/permissionManager/inrupt/WebIdManager";
@@ -7,31 +6,12 @@ import { PublicResolver } from "./classes/subjectResolvers/Public";
 import { WebIdResolver } from "./classes/subjectResolvers/WebId";
 import { PublicSubject, WebIdSubject } from "./types/subjects";
 
-export const activeController = new Controller<{
-    webId: WebIdSubject,
-    public: PublicSubject,
-}>(
-    new InruptStore("index.json", () => ({ id: "", items: [] })),
-    new InruptStore("resources.json", () => ({ id: "", items: [] })),
-    {
-        webId: {
-            resolver: new WebIdResolver(),
-            manager: new WebIdManager()
-        },
-        public: {
-            resolver: new PublicResolver(),
-            manager: new PublicManager(),
-        },
-    },
-)
-
 export const createBasicController = () => {
     return new Controller<{
         webId: WebIdSubject,
         public: PublicSubject,
     }>(
-        new InruptStore("index.json", () => ({ id: "", items: [] })),
-        new InruptStore("resources.json", () => ({ id: "", items: [] })),
+        InruptStore,
         {
             webId: {
                 resolver: new WebIdResolver(),
@@ -44,3 +24,5 @@ export const createBasicController = () => {
         },
     )
 }
+
+export const activeController = createBasicController()

--- a/controller/src/controllers.ts
+++ b/controller/src/controllers.ts
@@ -1,6 +1,7 @@
 import { Controller } from "./classes/Controller";
 import { PublicManager } from "./classes/permissionManager/inrupt/PublicManager";
 import { WebIdManager } from "./classes/permissionManager/inrupt/WebIdManager";
+import { InruptInboxStore } from "./classes/stores/InruptInboxStore";
 import { InruptStore } from "./classes/stores/InruptStore";
 import { PublicResolver } from "./classes/subjectResolvers/Public";
 import { WebIdResolver } from "./classes/subjectResolvers/WebId";
@@ -12,6 +13,7 @@ export const createBasicController = () => {
         public: PublicSubject,
     }>(
         InruptStore,
+        InruptInboxStore,
         {
             webId: {
                 resolver: new WebIdResolver(),

--- a/controller/src/types/index.ts
+++ b/controller/src/types/index.ts
@@ -47,3 +47,9 @@ export interface ResourcePermissions<T = BaseSubject<string>> {
     canRequestAccess: boolean;
     permissionsPerSubject: SubjectPermissions<T>[]
 }
+
+export interface ResourceAccessRequestNode {
+    resourceUrl: url;
+    canRequestAccess: boolean;
+    children?: Record<string, ResourceAccessRequestNode>;
+}

--- a/controller/src/types/index.ts
+++ b/controller/src/types/index.ts
@@ -1,5 +1,10 @@
 import { url } from "loama-common";
 
+export interface Resources {
+    id: url;
+    items: string[]
+}
+
 /**
  * The json schema for the index configuration file inside a Solid data pod.
  */

--- a/controller/src/types/index.ts
+++ b/controller/src/types/index.ts
@@ -44,5 +44,6 @@ export interface SubjectPermissions<T = BaseSubject<string>> {
 
 export interface ResourcePermissions<T = BaseSubject<string>> {
     resourceUrl: url;
+    canRequestAccess: boolean;
     permissionsPerSubject: SubjectPermissions<T>[]
 }

--- a/controller/src/types/index.ts
+++ b/controller/src/types/index.ts
@@ -53,3 +53,11 @@ export interface ResourceAccessRequestNode {
     canRequestAccess: boolean;
     children?: Record<string, ResourceAccessRequestNode>;
 }
+
+export type AccessRequestMessage = {
+    id: string;
+    actor: string;
+    requestedAt: string;
+    target: string;
+    permissions: string[];
+}

--- a/controller/src/types/index.ts
+++ b/controller/src/types/index.ts
@@ -57,7 +57,14 @@ export interface ResourceAccessRequestNode {
 export type AccessRequestMessage = {
     id: string;
     actor: string;
-    requestedAt: string;
+    requestedAt: Date;
+    target: string;
+    permissions: string[];
+}
+
+export type RequestResponseMessage = {
+    id: string;
+    isAccepted: boolean;
     target: string;
     permissions: string[];
 }

--- a/controller/src/types/index.ts
+++ b/controller/src/types/index.ts
@@ -1,5 +1,8 @@
 import { url } from "loama-common";
 
+/**
+ * The json schema for the resources file which holds the shareable resources inside a Solid data pod.
+ */
 export interface Resources {
     id: url;
     items: string[]
@@ -48,14 +51,22 @@ export interface ResourcePermissions<T = BaseSubject<string>> {
     permissionsPerSubject: SubjectPermissions<T>[]
 }
 
+/**
+  * The node structure used in the tree-structure for requestable resources
+  */
 export interface ResourceAccessRequestNode {
     resourceUrl: url;
     canRequestAccess: boolean;
+    /**
+    * A map of the next url part to the informationNode for select part
+    * eg. example.com/a/b/c is a map of "a" with "b" in it's children map etc.
+    */
     children?: Record<string, ResourceAccessRequestNode>;
 }
 
 export type AccessRequestMessage = {
     id: string;
+    // The webid of the person performing the request
     actor: string;
     requestedAt: Date;
     target: string;

--- a/controller/src/types/modules.ts
+++ b/controller/src/types/modules.ts
@@ -30,13 +30,15 @@ export interface IController<T extends Record<keyof T, BaseSubject<keyof T & str
     getContainerPermissionList(containerUrl: string): Promise<ResourcePermissions<T[keyof T]>[]>
 
     getResourcePermissionList(resourceUrl: string): Promise<ResourcePermissions<T[keyof T]>>
+}
 
+export interface IAccessRequest {
     canRequestAccessToResource(resourceUrl: string): Promise<boolean>
     allowAccessRequest(resourceUrl: string): Promise<void>
     disallowAccessRequest(resourceUrl: string): Promise<void>
 }
 
-export interface IStore<T extends Record<keyof T, BaseSubject<keyof T & string>>> {
+export interface IStore<T> {
     /**
     * Implemented by BaseStore
     * Will set the protected pod url property
@@ -47,32 +49,18 @@ export interface IStore<T extends Record<keyof T, BaseSubject<keyof T & string>>
     */
     unsetPodUrl(): void;
     /**
-    * Returns the currently stored index or calls getOrCreateIndex if the index is not set
+    * Returns the currently stored data or calls getOrCreate if the data is not set
     */
-    getCurrentIndex<K extends SubjectKey<T>>(): Promise<Index<T[K]>>;
+    getCurrent(): Promise<T>;
 
     /**
-    * Tries to retrieve the stored index.json from the pod. If it doesn't exist, it creates an empty one.
+    * Tries to retrieve the stored file from the pod. If it doesn't exist, it creates an empty one.
     */
-    getOrCreateIndex(): Promise<Index>;
+    getOrCreate(): Promise<T>;
     /**
-    * Saves the index to the pod
+    * Saves the data to the pod
     */
-    saveToRemoteIndex(): Promise<void>;
-
-    /**
-    * Returns the currently stored index or calls getOrCreateIndex if the index is not set
-    */
-    getCurrentResources(): Promise<Resources>;
-
-    /**
-    * Tries to retrieve the stored index.json from the pod. If it doesn't exist, it creates an empty one.
-    */
-    getOrCreateResources(): Promise<Resources>;
-    /**
-    * Saves the index to the pod
-    */
-    saveToRemoteResources(): Promise<void>;
+    saveToRemote(): Promise<void>;
 }
 
 export interface ISubjectResolver<T extends BaseSubject<string>> {

--- a/controller/src/types/modules.ts
+++ b/controller/src/types/modules.ts
@@ -11,6 +11,7 @@ export type SubjectConfigs<T extends Record<keyof T, BaseSubject<keyof T & strin
 export interface IController<T extends Record<keyof T, BaseSubject<keyof T & string>>> {
     setPodUrl(podUrl: string): void;
     unsetPodUrl(podUrl: string): void;
+    AccessRequest(): IAccessRequest;
     getLabelForSubject<K extends SubjectKey<T>>(subject: T[K]): string;
     getOrCreateIndex(): Promise<Index>;
     getItem<K extends SubjectKey<T>>(resourceUrl: string, subject: SubjectType<T, K>): Promise<IndexItem<T[K]> | undefined>;

--- a/controller/src/types/modules.ts
+++ b/controller/src/types/modules.ts
@@ -41,6 +41,9 @@ export interface IAccessRequest {
     canRequestAccessToResource(resourceUrl: string): Promise<boolean>
     allowAccessRequest(resourceUrl: string): Promise<void>
     disallowAccessRequest(resourceUrl: string): Promise<void>
+
+    // Notifications
+    sendRequestNotification(resources: string[]): Promise<void>;
 }
 
 export interface IStore<T> {
@@ -53,6 +56,8 @@ export interface IStore<T> {
     * Removes the pod url property value
     */
     unsetPodUrl(): void;
+    getPodUrl(): string | undefined;
+
     /**
     * Returns the currently stored data or calls getOrCreate if the data is not set
     */

--- a/controller/src/types/modules.ts
+++ b/controller/src/types/modules.ts
@@ -1,4 +1,4 @@
-import { BaseSubject, Index, IndexItem, Permission, ResourcePermissions, Resources, SubjectPermissions } from "../types";
+import { BaseSubject, Index, IndexItem, Permission, ResourceAccessRequestNode, ResourcePermissions, Resources, SubjectPermissions } from "../types";
 
 export type SubjectKey<T> = keyof T & string;
 export type SubjectType<T, K extends SubjectKey<T>> = T[K];
@@ -34,6 +34,10 @@ export interface IController<T extends Record<keyof T, BaseSubject<keyof T & str
 }
 
 export interface IAccessRequest {
+    /**
+    * Will return a tree structure starting from the containerUrl with the access requestable (container) resources
+    */
+    getRequestableResources(containerUrl: string): Promise<ResourceAccessRequestNode>
     canRequestAccessToResource(resourceUrl: string): Promise<boolean>
     allowAccessRequest(resourceUrl: string): Promise<void>
     disallowAccessRequest(resourceUrl: string): Promise<void>

--- a/controller/src/types/modules.ts
+++ b/controller/src/types/modules.ts
@@ -31,8 +31,9 @@ export interface IController<T extends Record<keyof T, BaseSubject<keyof T & str
 
     getResourcePermissionList(resourceUrl: string): Promise<ResourcePermissions<T[keyof T]>>
 
+    canRequestAccessToResource(resourceUrl: string): Promise<boolean>
     allowAccessRequest(resourceUrl: string): Promise<void>
-    denyAccessRequest(resourceUrl: string): Promise<void>
+    disallowAccessRequest(resourceUrl: string): Promise<void>
 }
 
 export interface IStore<T extends Record<keyof T, BaseSubject<keyof T & string>>> {

--- a/controller/src/types/modules.ts
+++ b/controller/src/types/modules.ts
@@ -1,4 +1,4 @@
-import { BaseSubject, Index, IndexItem, Permission, ResourcePermissions, SubjectPermissions } from "../types";
+import { BaseSubject, Index, IndexItem, Permission, ResourcePermissions, Resources, SubjectPermissions } from "../types";
 
 export type SubjectKey<T> = keyof T & string;
 export type SubjectType<T, K extends SubjectKey<T>> = T[K];
@@ -30,6 +30,9 @@ export interface IController<T extends Record<keyof T, BaseSubject<keyof T & str
     getContainerPermissionList(containerUrl: string): Promise<ResourcePermissions<T[keyof T]>[]>
 
     getResourcePermissionList(resourceUrl: string): Promise<ResourcePermissions<T[keyof T]>>
+
+    allowAccessRequest(resourceUrl: string): Promise<void>
+    denyAccessRequest(resourceUrl: string): Promise<void>
 }
 
 export interface IStore<T extends Record<keyof T, BaseSubject<keyof T & string>>> {
@@ -55,6 +58,20 @@ export interface IStore<T extends Record<keyof T, BaseSubject<keyof T & string>>
     * Saves the index to the pod
     */
     saveToRemoteIndex(): Promise<void>;
+
+    /**
+    * Returns the currently stored index or calls getOrCreateIndex if the index is not set
+    */
+    getCurrentResources(): Promise<Resources>;
+
+    /**
+    * Tries to retrieve the stored index.json from the pod. If it doesn't exist, it creates an empty one.
+    */
+    getOrCreateResources(): Promise<Resources>;
+    /**
+    * Saves the index to the pod
+    */
+    saveToRemoteResources(): Promise<void>;
 }
 
 export interface ISubjectResolver<T extends BaseSubject<string>> {

--- a/controller/src/types/modules.ts
+++ b/controller/src/types/modules.ts
@@ -46,6 +46,7 @@ export interface IAccessRequest {
 
     // Notifications
     sendRequestNotification(originWebId: string, resources: string[]): Promise<void>;
+    sendResponseNotification(type: "accept" | "reject", targetWebId: string): Promise<void>;
 
     loadAccessRequests(): Promise<AccessRequestMessage[]>
 

--- a/controller/src/types/modules.ts
+++ b/controller/src/types/modules.ts
@@ -41,8 +41,19 @@ export interface IAccessRequest {
     * Will return a tree structure starting from the containerUrl with the access requestable (container) resources
     */
     getRequestableResources(containerUrl: string): Promise<ResourceAccessRequestNode>
+
+    /**
+    * Checks if access to the resource is possible
+    * This should be based on the content of the resources.json file
+    */
     canRequestAccessToResource(resourceUrl: string): Promise<boolean>
+    /**
+    * Adds a resource to the shareable resource list (resources.json)
+    */
     allowAccessRequest(resourceUrl: string): Promise<void>
+    /**
+    * Removes a resource from the shareable resource list (resources.json)
+    */
     disallowAccessRequest(resourceUrl: string): Promise<void>
 
     // Notifications
@@ -51,6 +62,9 @@ export interface IAccessRequest {
 
     loadAccessRequests(): Promise<AccessRequestMessage[]>;
     loadRequestResponses(): Promise<RequestResponseMessage[]>;
+    /**
+    * Remove the given message resource from the inbox
+    */
     removeRequest(messageUrl: string): Promise<void>;
 }
 

--- a/controller/src/types/modules.ts
+++ b/controller/src/types/modules.ts
@@ -46,7 +46,7 @@ export interface IAccessRequest {
     disallowAccessRequest(resourceUrl: string): Promise<void>
 
     // Notifications
-    sendRequestNotification(originWebId: string, resources: string[]): Promise<void>;
+    sendRequestNotification(originWebId: string, resources: string[], permissions: Permission[]): Promise<void>;
     sendResponseNotification(type: "accept" | "reject", message: AccessRequestMessage): Promise<void>;
 
     loadAccessRequests(): Promise<AccessRequestMessage[]>;

--- a/controller/src/types/modules.ts
+++ b/controller/src/types/modules.ts
@@ -1,4 +1,4 @@
-import { BaseSubject, Index, IndexItem, Permission, ResourceAccessRequestNode, ResourcePermissions, SubjectPermissions } from "../types";
+import { AccessRequestMessage, BaseSubject, Index, IndexItem, Permission, ResourceAccessRequestNode, ResourcePermissions, SubjectPermissions } from "../types";
 
 export type SubjectKey<T> = keyof T & string;
 export type SubjectType<T, K extends SubjectKey<T>> = T[K];
@@ -46,6 +46,10 @@ export interface IAccessRequest {
 
     // Notifications
     sendRequestNotification(originWebId: string, resources: string[]): Promise<void>;
+
+    loadAccessRequests(): Promise<AccessRequestMessage[]>
+
+    removeRequest(messageUrl: string): Promise<void>;
 }
 
 export interface IInboxConstructor<T = unknown> {
@@ -86,6 +90,7 @@ export interface IStore<T> {
 }
 
 export interface IInbox<T = unknown> extends IStore<T[]> {
+    getMessages(): Promise<unknown[]>;
 }
 
 export interface ISubjectResolver<T extends BaseSubject<string>> {

--- a/controller/src/types/modules.ts
+++ b/controller/src/types/modules.ts
@@ -43,7 +43,7 @@ export interface IAccessRequest {
     disallowAccessRequest(resourceUrl: string): Promise<void>
 
     // Notifications
-    sendRequestNotification(resources: string[]): Promise<void>;
+    sendRequestNotification(originWebId: string, resources: string[]): Promise<void>;
 }
 
 export interface IStoreConstructor<T = unknown> {

--- a/controller/src/types/modules.ts
+++ b/controller/src/types/modules.ts
@@ -10,7 +10,7 @@ export type SubjectConfig<T extends Record<keyof T, BaseSubject<keyof T & string
 export type SubjectConfigs<T extends Record<keyof T, BaseSubject<keyof T & string>>> = Record<keyof T, SubjectConfig<T, T[keyof T]>>;
 
 export interface IController<T extends Record<keyof T, BaseSubject<keyof T & string>>> {
-    setPodUrl(podUrl: string): void;
+    setPodUrl(podUrl: string): Promise<void>;
     unsetPodUrl(podUrl: string): void;
     AccessRequest(): IAccessRequest;
     getLabelForSubject<K extends SubjectKey<T>>(subject: T[K]): string;

--- a/controller/src/types/modules.ts
+++ b/controller/src/types/modules.ts
@@ -1,4 +1,5 @@
-import { AccessRequestMessage, BaseSubject, Index, IndexItem, Permission, ResourceAccessRequestNode, ResourcePermissions, SubjectPermissions } from "../types";
+import { SolidDataset, WithResourceInfo } from "@inrupt/solid-client";
+import { AccessRequestMessage, BaseSubject, Index, IndexItem, Permission, RequestResponseMessage, ResourceAccessRequestNode, ResourcePermissions, SubjectPermissions } from "../types";
 
 export type SubjectKey<T> = keyof T & string;
 export type SubjectType<T, K extends SubjectKey<T>> = T[K];
@@ -48,8 +49,8 @@ export interface IAccessRequest {
     sendRequestNotification(originWebId: string, resources: string[]): Promise<void>;
     sendResponseNotification(type: "accept" | "reject", message: AccessRequestMessage): Promise<void>;
 
-    loadAccessRequests(): Promise<AccessRequestMessage[]>
-
+    loadAccessRequests(): Promise<AccessRequestMessage[]>;
+    loadRequestResponses(): Promise<RequestResponseMessage[]>;
     removeRequest(messageUrl: string): Promise<void>;
 }
 
@@ -91,7 +92,7 @@ export interface IStore<T> {
 }
 
 export interface IInbox<T = unknown> extends IStore<T[]> {
-    getMessages(): Promise<unknown[]>;
+    getMessages(): Promise<Record<string, SolidDataset & WithResourceInfo>>;
 }
 
 export interface ISubjectResolver<T extends BaseSubject<string>> {

--- a/controller/src/types/modules.ts
+++ b/controller/src/types/modules.ts
@@ -31,6 +31,8 @@ export interface IController<T extends Record<keyof T, BaseSubject<keyof T & str
     getContainerPermissionList(containerUrl: string): Promise<ResourcePermissions<T[keyof T]>[]>
 
     getResourcePermissionList(resourceUrl: string): Promise<ResourcePermissions<T[keyof T]>>
+
+    isSubjectSupported<T extends string>(subject: BaseSubject<T>): IController<Record<T, BaseSubject<T>>>
 }
 
 export interface IAccessRequest {
@@ -44,6 +46,10 @@ export interface IAccessRequest {
 
     // Notifications
     sendRequestNotification(originWebId: string, resources: string[]): Promise<void>;
+}
+
+export interface IInboxConstructor<T = unknown> {
+    new(filePath: string): IStore<T>
 }
 
 export interface IStoreConstructor<T = unknown> {

--- a/controller/src/types/modules.ts
+++ b/controller/src/types/modules.ts
@@ -62,6 +62,8 @@ export interface IStore<T> {
     unsetPodUrl(): void;
     getPodUrl(): string | undefined;
 
+    getDataUrl(): string;
+
     /**
     * Returns the currently stored data or calls getOrCreate if the data is not set
     */

--- a/controller/src/types/modules.ts
+++ b/controller/src/types/modules.ts
@@ -49,7 +49,7 @@ export interface IAccessRequest {
 }
 
 export interface IInboxConstructor<T = unknown> {
-    new(filePath: string): IStore<T>
+    new(filePath: string): IInbox<T>
 }
 
 export interface IStoreConstructor<T = unknown> {
@@ -83,6 +83,9 @@ export interface IStore<T> {
     * Saves the data to the pod
     */
     saveToRemote(): Promise<void>;
+}
+
+export interface IInbox<T = unknown> extends IStore<T[]> {
 }
 
 export interface ISubjectResolver<T extends BaseSubject<string>> {

--- a/controller/src/types/modules.ts
+++ b/controller/src/types/modules.ts
@@ -1,4 +1,4 @@
-import { BaseSubject, Index, IndexItem, Permission, ResourceAccessRequestNode, ResourcePermissions, Resources, SubjectPermissions } from "../types";
+import { BaseSubject, Index, IndexItem, Permission, ResourceAccessRequestNode, ResourcePermissions, SubjectPermissions } from "../types";
 
 export type SubjectKey<T> = keyof T & string;
 export type SubjectType<T, K extends SubjectKey<T>> = T[K];
@@ -44,6 +44,10 @@ export interface IAccessRequest {
 
     // Notifications
     sendRequestNotification(resources: string[]): Promise<void>;
+}
+
+export interface IStoreConstructor<T = unknown> {
+    new(filePath: string, templateGenerator: () => T): IStore<T>
 }
 
 export interface IStore<T> {

--- a/controller/src/types/modules.ts
+++ b/controller/src/types/modules.ts
@@ -46,7 +46,7 @@ export interface IAccessRequest {
 
     // Notifications
     sendRequestNotification(originWebId: string, resources: string[]): Promise<void>;
-    sendResponseNotification(type: "accept" | "reject", targetWebId: string): Promise<void>;
+    sendResponseNotification(type: "accept" | "reject", message: AccessRequestMessage): Promise<void>;
 
     loadAccessRequests(): Promise<AccessRequestMessage[]>
 

--- a/controller/src/util.ts
+++ b/controller/src/util.ts
@@ -1,5 +1,9 @@
 import { Session } from "@inrupt/solid-client-authn-browser"
 
-export const cacheBustedFetch = (session: Session) => (url: string | RequestInfo | URL, init?: RequestInit) => {
+export const cacheBustedSessionFetch = (session: Session) => (url: string | RequestInfo | URL, init?: RequestInit) => {
     return session.fetch(url, { ...init, cache: "no-cache" })
+}
+
+export const cacheBustedFetch = (url: string | RequestInfo | URL, init?: RequestInit) => {
+    return fetch(url, { ...init, cache: "no-cache" })
 }

--- a/loama/package.json
+++ b/loama/package.json
@@ -16,6 +16,7 @@
         "node": ">=20"
     },
     "dependencies": {
+        "@inrupt/solid-client": "^2.1.0",
         "@inrupt/solid-client-authn-browser": "^2.2.4",
         "@phosphor-icons/vue": "^2.2.1",
         "@primevue/themes": "^4.0.5",

--- a/loama/src/components/LoButton.vue
+++ b/loama/src/components/LoButton.vue
@@ -55,7 +55,6 @@ button {
     gap: var(--base-unit);
     border-radius: var(--base-corner);
     height: fit-content;
-    border: none;
     cursor: pointer;
     border: 0.25rem solid;
 }
@@ -68,7 +67,6 @@ button:hover {
 
 button:disabled {
     background-color: color-mix(in srgb, var(--off-black) 60%, transparent);
-    border: none;
     color: var(--off-white);
     cursor: not-allowed;
 }

--- a/loama/src/components/LoButton.vue
+++ b/loama/src/components/LoButton.vue
@@ -67,6 +67,7 @@ button:hover {
 
 button:disabled {
     background-color: color-mix(in srgb, var(--off-black) 60%, transparent);
+    border-color: color-mix(in srgb, var(--off-black) 60%, transparent);
     color: var(--off-white);
     cursor: not-allowed;
 }

--- a/loama/src/components/LoInput.vue
+++ b/loama/src/components/LoInput.vue
@@ -1,0 +1,31 @@
+<template>
+    <label :for="props.name">
+        <span v-if="props.label">{{ props.label }}</span>
+        <input v-model="model" :name="props.name" v-bind="$attrs" />
+    </label>
+</template>
+
+<script setup lang="ts">
+const model = defineModel();
+
+const props = defineProps<{ label?: string; name?: string }>();
+</script>
+
+<style lang="scss" scoped>
+label {
+    display: flex;
+    flex-direction: column;
+    font-weight: 700;
+}
+
+input {
+    padding: .5rem calc(var(--base-unit));
+    border-color: var(--off-black);
+    border-radius: var(--base-corner);
+
+    &:focus {
+        border-color: var(--solid-purple);
+        outline: none;
+    }
+}
+</style>

--- a/loama/src/components/LoginForm.vue
+++ b/loama/src/components/LoginForm.vue
@@ -50,9 +50,12 @@ const login = () => {
     isLoading.value = true;
     const issuer = solidPodUrl.value.trim() || defaultSolidPodUrl;
 
+    const searchParams = new URLSearchParams(location.search)
+    const nextPath = searchParams.get("next") ?? "home"
+
     store.session.login({
         oidcIssuer: issuer,
-        redirectUrl: new URL(`${import.meta.env.BASE_URL}home/`, window.location.href).toString(),
+        redirectUrl: new URL(`${import.meta.env.BASE_URL}${nextPath}/`, window.location.href).toString(),
         clientName: 'LOAMA',
     })
         .then(() => {

--- a/loama/src/components/explorer/SelectedEntry.vue
+++ b/loama/src/components/explorer/SelectedEntry.vue
@@ -52,9 +52,9 @@ const handleSubjectRequestAccess = (canRequest: boolean) => {
         throw new Error('No entry selected, this should not be possible');
     }
     if (canRequest) {
-        activeController.allowAccessRequest(podStore.selectedEntry.resourceUrl)
+        activeController.AccessRequest().allowAccessRequest(podStore.selectedEntry.resourceUrl)
     } else {
-        activeController.disallowAccessRequest(podStore.selectedEntry.resourceUrl)
+        activeController.AccessRequest().disallowAccessRequest(podStore.selectedEntry.resourceUrl)
     }
 
     podStore.refreshRequestAccessAllowance();

--- a/loama/src/components/explorer/SelectedEntry.vue
+++ b/loama/src/components/explorer/SelectedEntry.vue
@@ -6,11 +6,17 @@
             </ExplorerEntity>
             <PhXCircle :size="40" @click="$emit('close')" class="clickable" />
         </header>
-        <section>
+        <section class="entry-info">
             <div class="list-header">
                 <h3>Subjects with permissions:</h3>
                 <LoButton :left-icon="PhPencil" @click="() => permissionDrawerVisible = true">Edit</LoButton>
             </div>
+            <div class="access-request-switch">
+                <ToggleSwitch :modelValue="podStore.selectedEntry.canRequestAccess"
+                    @update:modelValue="handleSubjectRequestAccess" />
+                <span>Can people ask access to this resource?</span>
+            </div>
+            <p>Subjects with access:</p>
             <ul>
                 <li :key="activeController.getLabelForSubject(permission.subject)"
                     v-for="permission in podStore.selectedEntry.permissionsPerSubject">
@@ -35,10 +41,24 @@ import LoButton from '../LoButton.vue';
 import { ref } from 'vue';
 import Drawer from 'primevue/drawer';
 import SubjectPermissionTable from './SubjectPermissionTable.vue';
+import ToggleSwitch from 'primevue/toggleswitch';
 
 const podStore = usePodStore();
 
 const permissionDrawerVisible = ref(false);
+
+const handleSubjectRequestAccess = (canRequest: boolean) => {
+    if (!podStore.selectedEntry) {
+        throw new Error('No entry selected, this should not be possible');
+    }
+    if (canRequest) {
+        activeController.allowAccessRequest(podStore.selectedEntry.resourceUrl)
+    } else {
+        activeController.disallowAccessRequest(podStore.selectedEntry.resourceUrl)
+    }
+
+    podStore.refreshRequestAccessAllowance();
+}
 </script>
 
 <style scoped>
@@ -76,10 +96,20 @@ a {
     background-color: var(--solid-purple);
 }
 
+.entry-info>* {
+    margin: .5rem auto;
+}
+
 .list-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
+}
+
+.access-request-switch {
+    display: flex;
+    flex-direction: row;
+    gap: .5rem;
 }
 </style>
 <style src="@vueform/multiselect/themes/default.css"></style>

--- a/loama/src/components/header/HeaderTab.vue
+++ b/loama/src/components/header/HeaderTab.vue
@@ -1,7 +1,7 @@
 <template>
-    <a :href="href" :class="{ active: active }">
+    <RouterLink :to="href" activeClass="active">
         <slot />
-    </a>
+    </RouterLink>
 </template>
 
 <script setup lang="ts">
@@ -14,6 +14,7 @@ defineProps<{
 <style scoped>
 a {
     background-color: var(--lama-gray);
+    color: var(--off-black);
     display: inline-block;
     text-decoration: none;
     display: flex;

--- a/loama/src/components/inbox/AccessRequestMessage.vue
+++ b/loama/src/components/inbox/AccessRequestMessage.vue
@@ -1,0 +1,72 @@
+<template>
+    <div class="container">
+        <p><span class="prefix">From:</span> {{ message.actor }}</p>
+        <p><span class="prefix">Target:</span> {{ message.target }}</p>
+        <div>
+            <span class="prefix">Requested: </span>
+            <p v-for="label in aclLabels" :key="label">{{ label }}</p>
+        </div>
+        <div class="actions">
+            <LoButton variant="secondary">Reject</LoButton>
+            <LoButton>Accept</LoButton>
+        </div>
+    </div>
+</template>
+<script setup lang="ts">
+import { activeController, type AccessRequestMessage } from 'loama-controller';
+import { computed } from 'vue';
+import LoButton from '../LoButton.vue';
+
+const props = defineProps<{
+    message: AccessRequestMessage
+}>()
+
+const aclLabels = computed(() => props.message.permissions.map(getLabelForAclPermission));
+
+const aclToLabel: Record<string, string> = {
+    "acl:Read": "Read",
+    "acl:Append": "Append",
+    "acl:Write": "Write",
+    "acl:Control": "Control",
+}
+
+const getLabelForAclPermission = (permission: string) => {
+    let label = aclToLabel[permission];
+    if (!label) {
+        console.error(`No label for ${permission}`);
+        label = permission;
+    }
+    return label
+}
+
+const acceptAccessRequest = async () => {
+    await activeController.AccessRequest.removeRequest(props.message.id)
+}
+
+const rejectAccessRequest = async () => {
+    await activeController.AccessRequest.removeRequest(props.message.id)
+}
+</script>
+<style scoped lang="scss">
+.container {
+    padding: .5rem;
+    border: 1px solid var(--solid-purple);
+    border-radius: .5rem;
+    text-align: left;
+
+    &>div {
+        display: flex;
+        flex-direction: row;
+        gap: .25rem;
+    }
+}
+
+.prefix {
+    font-weight: 700;
+}
+
+.actions {
+    display: flex;
+    gap: .5rem;
+}
+</style>

--- a/loama/src/components/inbox/AccessRequestMessage.vue
+++ b/loama/src/components/inbox/AccessRequestMessage.vue
@@ -3,7 +3,7 @@
         <p><span class="prefix">From:</span> {{ message.actor }}</p>
         <p><span class="prefix">Target:</span> {{ message.target }}</p>
         <div>
-            <span class="prefix">Requested: </span>
+            <span class="prefix">Requested Permissions: </span>
             <p v-for="label in aclLabels" :key="label">{{ label }}</p>
         </div>
         <div class="actions">

--- a/loama/src/components/inbox/AccessRequestMessage.vue
+++ b/loama/src/components/inbox/AccessRequestMessage.vue
@@ -7,44 +7,121 @@
             <p v-for="label in aclLabels" :key="label">{{ label }}</p>
         </div>
         <div class="actions">
-            <LoButton variant="secondary">Reject</LoButton>
-            <LoButton>Accept</LoButton>
+            <LoButton @click="rejectAccessRequest" variant="secondary">Reject</LoButton>
+            <LoButton @click="acceptAccessRequest">Accept</LoButton>
         </div>
     </div>
 </template>
 <script setup lang="ts">
-import { activeController, type AccessRequestMessage } from 'loama-controller';
+import { Permission, activeController, createBasicController, type AccessRequestMessage } from 'loama-controller';
 import { computed } from 'vue';
 import LoButton from '../LoButton.vue';
+import { useToast } from 'primevue/usetoast';
+import { getDefaultSession } from '@inrupt/solid-client-authn-browser';
+import { listWebIdPodUrls } from 'loama-common';
 
+const toast = useToast();
 const props = defineProps<{
     message: AccessRequestMessage
 }>()
+const emit = defineEmits<{
+    (e: 'reload'): void
+}>();
 
 const aclLabels = computed(() => props.message.permissions.map(getLabelForAclPermission));
 
-const aclToLabel: Record<string, string> = {
-    "acl:Read": "Read",
-    "acl:Append": "Append",
-    "acl:Write": "Write",
-    "acl:Control": "Control",
+const aclToInfo: Record<string, { label: string, value: Permission }> = {
+    "acl:Read": {
+        label: "Read",
+        value: Permission.Read
+    },
+    "acl:Append": {
+        label: "Append",
+        value: Permission.Append
+    },
+    "acl:Write": {
+        label: "Write",
+        value: Permission.Write
+    },
+    "acl:Control": {
+        label: "Control",
+        value: Permission.Control,
+    },
 }
 
 const getLabelForAclPermission = (permission: string) => {
-    let label = aclToLabel[permission];
+    let label = aclToInfo[permission]?.label;
     if (!label) {
-        console.error(`No label for ${permission}`);
+        console.error(`No info for ${permission}`);
         label = permission;
     }
     return label
 }
 
+const getActorController = async () => {
+    const actorController = createBasicController();
+    const session = getDefaultSession();
+    let pods = await listWebIdPodUrls(props.message.actor, session.fetch);
+    actorController.setPodUrl(pods[0])
+    return actorController
+}
+
 const acceptAccessRequest = async () => {
-    await activeController.AccessRequest.removeRequest(props.message.id)
+    for (const acl of props.message.permissions) {
+        const permission = aclToInfo[acl]?.value;
+        if (!permission) {
+            console.error(`No permission assigned to requested permission: ${acl}`)
+            continue;
+        }
+        await activeController.addPermission(props.message.target, permission, {
+            type: "webId",
+            selector: {
+                url: props.message.actor
+            }
+        });
+    }
+
+    const actorController = await getActorController();
+    try {
+        await activeController.AccessRequest().removeRequest(props.message.id)
+        await actorController.AccessRequest().sendResponseNotification("accept", props.message.target);
+        toast.add({
+            severity: "success",
+            summary: "Access request accepted",
+            detail: `Request from ${props.message.actor} to ${props.message.target}`,
+            life: 3000,
+        })
+        emit("reload")
+    } catch (e) {
+        toast.add({
+            severity: "error",
+            summary: "Failed to deny access request",
+            detail: e instanceof Error ? e.message : `An unknown error happened: ${e}`,
+            life: 3000,
+        })
+    }
 }
 
 const rejectAccessRequest = async () => {
-    await activeController.AccessRequest.removeRequest(props.message.id)
+    const actorController = await getActorController();
+    try {
+        await activeController.AccessRequest().removeRequest(props.message.id)
+        await actorController.AccessRequest().sendResponseNotification("reject", props.message.target);
+        toast.add({
+            severity: "info",
+            summary: "Access request denied",
+            detail: `Request from ${props.message.actor} to ${props.message.target}`,
+            life: 3000,
+        })
+        emit("reload")
+    } catch (e) {
+        toast.add({
+            severity: "error",
+            summary: "Failed to deny access request",
+            detail: e instanceof Error ? e.message : `An unknown error happened: ${e}`,
+            life: 3000,
+        })
+    }
 }
 </script>
 <style scoped lang="scss">
@@ -68,5 +145,6 @@ const rejectAccessRequest = async () => {
 .actions {
     display: flex;
     gap: .5rem;
+    float: right;
 }
 </style>

--- a/loama/src/components/inbox/AccessRequestMessage.vue
+++ b/loama/src/components/inbox/AccessRequestMessage.vue
@@ -84,7 +84,7 @@ const acceptAccessRequest = async () => {
     const actorController = await getActorController();
     try {
         await activeController.AccessRequest().removeRequest(props.message.id)
-        await actorController.AccessRequest().sendResponseNotification("accept", props.message.target);
+        await actorController.AccessRequest().sendResponseNotification("accept", props.message);
         toast.add({
             severity: "success",
             summary: "Access request accepted",
@@ -106,7 +106,7 @@ const rejectAccessRequest = async () => {
     const actorController = await getActorController();
     try {
         await activeController.AccessRequest().removeRequest(props.message.id)
-        await actorController.AccessRequest().sendResponseNotification("reject", props.message.target);
+        await actorController.AccessRequest().sendResponseNotification("reject", props.message);
         toast.add({
             severity: "info",
             summary: "Access request denied",

--- a/loama/src/components/inbox/RequestInbox.vue
+++ b/loama/src/components/inbox/RequestInbox.vue
@@ -1,19 +1,40 @@
 <template>
-    <h3>Incoming Access Requests</h3>
+    <div class="header">
+        <h3>Incoming Access Requests</h3>
+        <PhArrowClockwise weight="bold" :size="32" @click="reloadMessages" />
+    </div>
     <div class="request-list">
-        <AccessRequestMessage v-for="message in messages" :key="message.id" :message="message" />
+        <AccessRequestMessage v-for="message in messages" :key="message.id" :message="message"
+            @reload="reloadMessages" />
     </div>
 </template>
 <script setup lang="ts">
 import { activeController } from 'loama-controller';
 import AccessRequestMessage from './AccessRequestMessage.vue';
+import { PhArrowClockwise } from '@phosphor-icons/vue';
 
-const messages = await activeController.AccessRequest().loadAccessRequests();
+let messages = await activeController.AccessRequest().loadAccessRequests();
+
+const reloadMessages = async () => {
+    messages = await activeController.AccessRequest().loadAccessRequests();
+}
 </script>
-<style scoped>
+<style scoped lang="scss">
 .request-list {
     display: flex;
     flex-direction: column;
     gap: .5rem;
+}
+
+.header {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.5rem;
+
+    &>svg {
+        justify-self: end;
+        cursor: pointer;
+    }
 }
 </style>

--- a/loama/src/components/inbox/RequestInbox.vue
+++ b/loama/src/components/inbox/RequestInbox.vue
@@ -1,0 +1,19 @@
+<template>
+    <h3>Incoming Access Requests</h3>
+    <div class="request-list">
+        <AccessRequestMessage v-for="message in messages" :key="message.id" :message="message" />
+    </div>
+</template>
+<script setup lang="ts">
+import { activeController } from 'loama-controller';
+import AccessRequestMessage from './AccessRequestMessage.vue';
+
+const messages = await activeController.AccessRequest().loadAccessRequests();
+</script>
+<style scoped>
+.request-list {
+    display: flex;
+    flex-direction: column;
+    gap: .5rem;
+}
+</style>

--- a/loama/src/components/inbox/RequestResponseMessage.vue
+++ b/loama/src/components/inbox/RequestResponseMessage.vue
@@ -1,0 +1,63 @@
+<template>
+    <div class="container">
+        <div><p class="prefix">Accepted:</p><PhCheckCircle v-if="message.isAccepted" weight="bold" /><PhXCircle v-else weight="bold" /></div>
+        <p><span class="prefix">To:</span> {{ message.target }}</p>
+        <div>
+            <span class="prefix">Requested Permissions: </span>
+            <p v-for="label in aclLabels" :key="label">{{ label }}</p>
+        </div>
+        <div class="actions">
+            <LoButton @click="confirmMessage">Confirm</LoButton>
+        </div>
+    </div>
+</template>
+<script setup lang="ts">
+import { PhCheckCircle, PhXCircle } from '@phosphor-icons/vue';
+import { activeController, type RequestResponseMessage } from 'loama-controller';
+import { computed } from 'vue';
+import LoButton from '../LoButton.vue';
+
+const props = defineProps<{
+    message: RequestResponseMessage,
+}>();
+const emit = defineEmits<{
+    (e: "reload"): void,
+}>();
+
+const aclLabels = computed(() => props.message.permissions.map(p => aclToLabel[p] ?? p));
+const aclToLabel: Record<string, string> = {
+    "acl:Read": "Read",
+    "acl:Append": "Append",
+    "acl:Write": "Write",
+    "acl:Control": "Control",
+}
+
+const confirmMessage = async () => {
+    await activeController.AccessRequest().removeRequest(props.message.id);
+    emit("reload")
+}
+
+</script>
+<style lang="scss" scoped>
+.container {
+    padding: .5rem;
+    border: 1px solid var(--solid-purple);
+    border-radius: .5rem;
+    text-align: left;
+
+    &>div {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: .25rem;
+    }
+
+    &>p {
+        display: inline;
+    }
+}
+
+.actions {
+    float: right;
+}
+</style>

--- a/loama/src/components/inbox/RequestResponseMessage.vue
+++ b/loama/src/components/inbox/RequestResponseMessage.vue
@@ -1,13 +1,17 @@
 <template>
     <div class="container">
-        <div><p class="prefix">Accepted:</p><PhCheckCircle v-if="message.isAccepted" weight="bold" /><PhXCircle v-else weight="bold" /></div>
-        <p><span class="prefix">To:</span> {{ message.target }}</p>
+        <div>
+            <p class="prefix">Accepted:</p>
+            <PhCheckCircle v-if="message.isAccepted" weight="bold" />
+            <PhXCircle v-else weight="bold" />
+        </div>
+        <p><span class="prefix">Target:</span> {{ message.target }}</p>
         <div>
             <span class="prefix">Requested Permissions: </span>
             <p v-for="label in aclLabels" :key="label">{{ label }}</p>
         </div>
         <div class="actions">
-            <LoButton @click="confirmMessage">Confirm</LoButton>
+            <LoButton @click="confirmMessage">Mark as read</LoButton>
         </div>
     </div>
 </template>

--- a/loama/src/components/inbox/ResponseInbox.vue
+++ b/loama/src/components/inbox/ResponseInbox.vue
@@ -1,23 +1,23 @@
 <template>
     <div class="header">
-        <h3>Incoming Access Requests</h3>
+        <h3>Request Responses</h3>
         <PhArrowClockwise weight="bold" :size="32" @click="reloadMessages" />
     </div>
     <div class="request-list">
-        <AccessRequestMessage v-for="message in messages" :key="message.id" :message="message"
+        <RequestResponseMessage v-for="message in messages" :key="message.id" :message="message"
             @reload="reloadMessages" />
     </div>
 </template>
 <script setup lang="ts">
 import { activeController } from 'loama-controller';
-import AccessRequestMessage from './AccessRequestMessage.vue';
 import { PhArrowClockwise } from '@phosphor-icons/vue';
+import RequestResponseMessage from './RequestResponseMessage.vue';
 import { ref } from 'vue';
 
-let messages = ref(await activeController.AccessRequest().loadAccessRequests());
+let messages = ref(await activeController.AccessRequest().loadRequestResponses());
 
 const reloadMessages = async () => {
-    messages.value = await activeController.AccessRequest().loadAccessRequests();
+    messages.value = await activeController.AccessRequest().loadRequestResponses();
 }
 </script>
 <style scoped lang="scss">

--- a/loama/src/components/layouts/HeaderLayout.vue
+++ b/loama/src/components/layouts/HeaderLayout.vue
@@ -1,0 +1,13 @@
+<template>
+    <Suspense>
+        <HeaderBase>
+            <HeaderTab href="/home/" active>Resources</HeaderTab>
+            <HeaderTab href="/request" active>Request access</HeaderTab>
+        </HeaderBase>
+    </Suspense>
+    <router-view />
+</template>
+<script setup lang='ts'>
+import HeaderTab from "@/components/header/HeaderTab.vue";
+import HeaderBase from '@/components/header/HeaderBase.vue'
+</script>

--- a/loama/src/components/layouts/HeaderLayout.vue
+++ b/loama/src/components/layouts/HeaderLayout.vue
@@ -3,6 +3,7 @@
         <HeaderBase>
             <HeaderTab href="/home/" active>Resources</HeaderTab>
             <HeaderTab href="/request" active>Request access</HeaderTab>
+            <HeaderTab href="/inbox" active>Access Requests</HeaderTab>
         </HeaderBase>
     </Suspense>
     <router-view />

--- a/loama/src/components/popups/RequestWebIdPopup.vue
+++ b/loama/src/components/popups/RequestWebIdPopup.vue
@@ -1,0 +1,57 @@
+<template>
+    <div class="popup-container">
+        <PhQuestion :size="24" @mouseover="showPopup = true;" @mouseleave="showPopup = false" />
+        <div class="floating-popup" v-if="showPopup">
+            <h3>{{ title }}</h3>
+            <p>{{ message }}</p>
+        </div>
+    </div>
+</template>
+<script setup lang='ts'>
+import { PhQuestion } from '@phosphor-icons/vue';
+import { ref } from 'vue';
+
+defineProps<{title: string; message: string}>()
+
+let showPopup = ref(false)
+</script>
+<style scoped>
+.popup-container {
+    position: relative;
+}
+
+.floating-popup {
+    position: absolute;
+    z-index: 10;
+    left: 30px;
+    top: 0;
+    border: 0.25rem solid var(--solid-purple);
+    background-color: var(--off-white);
+    padding: var(--base-unit);
+    border-radius: var(--base-corner);
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    width: 30rem;
+}
+
+h3 {
+    margin-bottom: calc(var(--base-unit) * 2);
+    font-size: calc(var(--base-unit)*3);
+}
+
+p {
+    margin-bottom: calc(var(--base-unit));
+}
+
+aside {
+    display: flex;
+    padding: 8px;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    border-radius: var(--base-corner);
+    background-color: var(--solid-purple);
+    color: var(--off-white);
+}
+</style>

--- a/loama/src/lib/state.ts
+++ b/loama/src/lib/state.ts
@@ -57,7 +57,7 @@ export const usePodStore = defineStore("pod", {
             if (!this.selectedEntry) {
                 throw new Error('No selected entry to update permissions for');
             }
-            this.selectedEntry.canRequestAccess = await activeController.canRequestAccessToResource(this.selectedEntry.resourceUrl);
+            this.selectedEntry.canRequestAccess = await activeController.AccessRequest().canRequestAccessToResource(this.selectedEntry.resourceUrl);
         }
     }
 })

--- a/loama/src/lib/state.ts
+++ b/loama/src/lib/state.ts
@@ -1,4 +1,3 @@
-import { ref } from "vue";
 import type { Entry } from "./types";
 import { activeController, type PublicSubject, type ResourcePermissions, type WebIdSubject } from "loama-controller";
 import { defineStore } from "pinia";
@@ -54,5 +53,11 @@ export const usePodStore = defineStore("pod", {
             const newResourceInfo = await activeController.getResourcePermissionList(this.selectedEntry.resourceUrl);
             this.selectedEntry.permissionsPerSubject = newResourceInfo.permissionsPerSubject;
         },
+        async refreshRequestAccessAllowance() {
+            if (!this.selectedEntry) {
+                throw new Error('No selected entry to update permissions for');
+            }
+            this.selectedEntry.canRequestAccess = await activeController.canRequestAccessToResource(this.selectedEntry.resourceUrl);
+        }
     }
 })

--- a/loama/src/lib/utils.ts
+++ b/loama/src/lib/utils.ts
@@ -3,3 +3,17 @@ export const uriToName = (uri: string, isContainer: boolean) => {
 
     return isContainer ? splitted[splitted.length - 2] : splitted[splitted.length - 1];
 }
+
+export const debounce = (fn: Function, wait: number) => {
+    let timer: NodeJS.Timeout;
+    return function(...args: any[]) {
+        if (timer) {
+            clearTimeout(timer); // clear any pre-existing timer
+        }
+        // @ts-expect-error this is the current context
+        const context = this; // get the current context
+        timer = setTimeout(() => {
+            fn.apply(context, args); // call the function if time expires
+        }, wait);
+    }
+}

--- a/loama/src/lib/utils.ts
+++ b/loama/src/lib/utils.ts
@@ -1,3 +1,5 @@
+import { Permission } from "loama-controller";
+
 export const uriToName = (uri: string, isContainer: boolean) => {
     const splitted = uri.split('/');
 
@@ -17,3 +19,10 @@ export const debounce = (fn: Function, wait: number) => {
         }, wait);
     }
 }
+
+export const allPermissions = [
+    Permission.Read,
+    Permission.Write,
+    Permission.Append,
+    Permission.Control,
+]

--- a/loama/src/router/index.ts
+++ b/loama/src/router/index.ts
@@ -1,9 +1,11 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '@/views/HomeView.vue'
 import LoginView from '@/views/LoginView.vue'
+import RequestView from '@/views/RequestView.vue'
 import { store } from 'loama-app'
 import { listPodUrls } from 'loama-common'
 import { activeController } from 'loama-controller'
+import HeaderLayout from '@/components/layouts/HeaderLayout.vue'
 
 const router = createRouter({
     history: createWebHistory(import.meta.env.BASE_URL),
@@ -14,9 +16,20 @@ const router = createRouter({
             component: LoginView
         },
         {
-            path: `/home/:filePath(.*)`,
-            name: 'home',
-            component: HomeView
+            path: "/",
+            component: HeaderLayout,
+            children: [
+                {
+                    path: `/home/:filePath(.*)`,
+                    name: 'home',
+                    component: HomeView
+                },
+                {
+                    path: "/request",
+                    name: "request",
+                    component: RequestView,
+                }
+            ]
         }
     ]
 })

--- a/loama/src/router/index.ts
+++ b/loama/src/router/index.ts
@@ -6,6 +6,7 @@ import { store } from 'loama-app'
 import { listPodUrls } from 'loama-common'
 import { activeController } from 'loama-controller'
 import HeaderLayout from '@/components/layouts/HeaderLayout.vue'
+import InboxView from '@/views/InboxView.vue'
 
 const router = createRouter({
     history: createWebHistory(import.meta.env.BASE_URL),
@@ -28,6 +29,11 @@ const router = createRouter({
                     path: "/request",
                     name: "request",
                     component: RequestView,
+                },
+                {
+                    path: "/inbox",
+                    name: "inbox",
+                    component: InboxView,
                 }
             ]
         }

--- a/loama/src/router/index.ts
+++ b/loama/src/router/index.ts
@@ -52,7 +52,7 @@ router.beforeEach(async (to) => {
             store.setUsedPod(currentPodUrl)
         }
         if (!store.session.info.isLoggedIn && to.name !== 'login') {
-            return { name: 'login' }
+            return { name: 'login', query: { "next": to.name?.toString() } }
         }
     }
 })

--- a/loama/src/router/index.ts
+++ b/loama/src/router/index.ts
@@ -48,7 +48,7 @@ router.beforeEach(async (to) => {
         if (store.session.info.isLoggedIn) {
             // Default to the first pod
             const currentPodUrl = (await listPodUrls(store.session))[0]
-            activeController.setPodUrl(currentPodUrl);
+            await activeController.setPodUrl(currentPodUrl);
             store.setUsedPod(currentPodUrl)
         }
         if (!store.session.info.isLoggedIn && to.name !== 'login') {

--- a/loama/src/views/HomeView.vue
+++ b/loama/src/views/HomeView.vue
@@ -1,9 +1,4 @@
 <template>
-    <Suspense>
-        <HeaderBase>
-            <HeaderTab href="/home" active>Resources</HeaderTab>
-        </HeaderBase>
-    </Suspense>
     <main>
         <Suspense>
             <ResourceExplorer />
@@ -15,8 +10,6 @@
 </template>
 
 <script setup lang="ts">
-import HeaderTab from "../components/header/HeaderTab.vue";
-import HeaderBase from '../components/header/HeaderBase.vue'
 import ResourceExplorer from '../components/explorer/ResourceExplorer.vue'
 import FallbackExplorer from '../components/explorer/FallbackExplorer.vue'
 </script>

--- a/loama/src/views/InboxView.vue
+++ b/loama/src/views/InboxView.vue
@@ -5,7 +5,7 @@
                 <RequestInbox />
             </div>
             <div>
-                <h3>Accepted request</h3>
+                <ResponseInbox />
             </div>
         </div>
         <template #fallback>
@@ -17,6 +17,7 @@
 <script lang="ts" setup>
 import FallbackExplorer from '@/components/explorer/FallbackExplorer.vue';
 import RequestInbox from '@/components/inbox/RequestInbox.vue';
+import ResponseInbox from '@/components/inbox/ResponseInbox.vue';
 
 </script>
 <style scoped lang="scss">

--- a/loama/src/views/InboxView.vue
+++ b/loama/src/views/InboxView.vue
@@ -1,0 +1,38 @@
+<template>
+    <Suspense>
+        <div class="container">
+            <div>
+                <RequestInbox />
+            </div>
+            <div>
+                <h3>Accepted request</h3>
+            </div>
+        </div>
+        <template #fallback>
+            <FallbackExplorer>Loading access requests...</FallbackExplorer>
+        </template>
+    </Suspense>
+</template>
+
+<script lang="ts" setup>
+import FallbackExplorer from '@/components/explorer/FallbackExplorer.vue';
+import RequestInbox from '@/components/inbox/RequestInbox.vue';
+
+</script>
+<style scoped lang="scss">
+.container {
+    display: flex;
+    height: calc(100vh - var(--base-unit)*14);
+
+    &>*:first-child {
+        border-right: 0.25rem solid var(--solid-purple);
+    }
+
+    &>* {
+        flex: 1;
+        height: 100%;
+        padding: .5rem;
+        text-align: center;
+    }
+}
+</style>

--- a/loama/src/views/RequestView.vue
+++ b/loama/src/views/RequestView.vue
@@ -4,19 +4,22 @@
             <LoInput v-model="webId" name="webid" label="Web ID" />
             <Select v-model="selectedPodUrl" :options="podUrls" />
         </div>
-        <Tree v-model:selectionKeys="selectedEntries" :value="requestableFiles" @node-expand="onNodeExpand"
-            selectionMode="checkbox" class="w-full md:w-[30rem]"></Tree>
+        <Tree v-model:selectionKeys="selectedEntries" :value="requestableFiles" selectionMode="checkbox"
+            class="w-full md:w-[30rem]" />
+        <LoButton>Request Access</LoButton>
     </div>
 </template>
 <script setup lang="ts">
 import LoInput from '@/components/LoInput.vue';
 import { getDefaultSession } from '@inrupt/solid-client-authn-browser';
-import { createBasicController } from 'loama-controller';
+import { createBasicController, type ResourceAccessRequestNode } from 'loama-controller';
 import { ref, watch } from 'vue';
 import Select from 'primevue/select';
 import { listWebIdPodUrls } from 'loama-common';
 import Tree, { type TreeSelectionKeys } from 'primevue/tree';
 import type { TreeNode } from 'primevue/treenode';
+import { debounce } from '@/lib/utils';
+import LoButton from '@/components/LoButton.vue';
 
 const webId = ref("");
 const podUrls = ref<string[]>([]);
@@ -24,27 +27,41 @@ const selectedPodUrl = ref<string>("");
 const selectedEntries = ref<TreeSelectionKeys>({});
 const requestableFiles = ref<TreeNode[]>([]);
 const controller = ref(createBasicController());
-
-const onNodeExpand = (node: TreeNode) => {
-
-}
-
-watch(webId, async (newVal) => {
+const debouncedPodFetcher = debounce(async (newVal: string) => {
     const session = getDefaultSession();
     let pods = await listWebIdPodUrls(newVal, session.fetch);
     podUrls.value = pods;
+}, 1000)
+
+const accessRequestNodeToTreeNode = (key: string, node: ResourceAccessRequestNode): TreeNode => {
+    return {
+        key: node.resourceUrl,
+        label: key,
+        selectable: node.canRequestAccess,
+        children: node.children ? Object.entries(node.children).map(([k, node]) => accessRequestNodeToTreeNode(k, node)) : undefined,
+    }
+};
+
+watch(webId, async (newVal) => {
+    debouncedPodFetcher(newVal);
 })
 
-watch(selectedPodUrl, (newPodUrl) => {
+watch(selectedPodUrl, async (newPodUrl) => {
     controller.value.setPodUrl(newPodUrl);
-    // TODO: Only fetch the files where we can request access to
-    const files = controller.value.getContainerPermissionList(newPodUrl);
+    const podNode = await controller.value.AccessRequest().getRequestableResources(newPodUrl);
+    requestableFiles.value = [
+        accessRequestNodeToTreeNode(newPodUrl, podNode),
+    ];
 });
 
 </script>
-<style scoped>
+<style lang="scss" scoped>
 .container {
     padding: .5rem;
+
+    &>*:not(:first-child) {
+        margin-top: .5rem;
+    }
 }
 
 .header {

--- a/loama/src/views/RequestView.vue
+++ b/loama/src/views/RequestView.vue
@@ -1,5 +1,64 @@
 <template>
-    <p>Request</p>
+    <div class="container">
+        <div class="header">
+            <LoInput v-model="webId" name="webid" label="Web ID" />
+            <Select v-model="selectedPodUrl" :options="podUrls" />
+        </div>
+        <Tree v-model:selectionKeys="selectedEntries" :value="requestableFiles" @node-expand="onNodeExpand"
+            selectionMode="checkbox" class="w-full md:w-[30rem]"></Tree>
+    </div>
 </template>
 <script setup lang="ts">
+import LoInput from '@/components/LoInput.vue';
+import { getDefaultSession } from '@inrupt/solid-client-authn-browser';
+import { createBasicController } from 'loama-controller';
+import { ref, watch } from 'vue';
+import Select from 'primevue/select';
+import { listWebIdPodUrls } from 'loama-common';
+import Tree, { type TreeSelectionKeys } from 'primevue/tree';
+import type { TreeNode } from 'primevue/treenode';
+
+const webId = ref("");
+const podUrls = ref<string[]>([]);
+const selectedPodUrl = ref<string>("");
+const selectedEntries = ref<TreeSelectionKeys>({});
+const requestableFiles = ref<TreeNode[]>([]);
+const controller = ref(createBasicController());
+
+const onNodeExpand = (node: TreeNode) => {
+
+}
+
+watch(webId, async (newVal) => {
+    const session = getDefaultSession();
+    let pods = await listWebIdPodUrls(newVal, session.fetch);
+    podUrls.value = pods;
+})
+
+watch(selectedPodUrl, (newPodUrl) => {
+    controller.value.setPodUrl(newPodUrl);
+    // TODO: Only fetch the files where we can request access to
+    const files = controller.value.getContainerPermissionList(newPodUrl);
+});
+
 </script>
+<style scoped>
+.container {
+    padding: .5rem;
+}
+
+.header {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: .5rem;
+
+    &>* {
+        width: 100%;
+    }
+
+    &>.p-select {
+        height: min-content;
+    }
+}
+</style>

--- a/loama/src/views/RequestView.vue
+++ b/loama/src/views/RequestView.vue
@@ -1,0 +1,5 @@
+<template>
+    <p>Request</p>
+</template>
+<script setup lang="ts">
+</script>

--- a/loama/src/views/RequestView.vue
+++ b/loama/src/views/RequestView.vue
@@ -1,11 +1,29 @@
 <template>
     <div class="container">
         <div class="header">
-            <LoInput v-model="webId" name="webid" label="Web ID" />
-            <Select v-model="selectedPodUrl" :options="podUrls" />
+            <div>
+                <label class="input-label" for="webid">
+                    <span>Web ID </span>
+                    <RequestWebIdPopup title="Target Web Id" message="The web ID url where you want to request access to files." />
+                </label>
+                <LoInput v-model="webId" name="webid" />
+            </div>
+            <div>
+                <label class="input-label" for="webid">
+                    <span>Pod</span>
+                    <RequestWebIdPopup title="Target pod" message="Select one of the pods (retrieved from the given web Id). The pods should have access requestable resources" />
+                </label>
+                <Select name="pod-url" v-model="selectedPodUrl" :options="podUrls" placeholder="Select a pod URL" />
+            </div>
         </div>
         <Tree v-model:selectionKeys="selectedEntries" :value="requestableFiles" selectionMode="checkbox"
-            class="w-full md:w-[30rem]" />
+            class="w-full md:w-[30rem]" v-if="requestableFiles.length > 0" />
+        <div v-else-if="selectedPodUrl !== '' && requestableFiles.length === 0">
+            <p>This pod doesn't contain any files which you can request access to</p>
+        </div>
+        <div v-else>
+            <p>No pod selected!</p>
+        </div>
         <LoButton @click="sendRequestNotification" :disabled="Object.keys(selectedEntries).length < 1">Request Access
         </LoButton>
     </div>
@@ -22,6 +40,7 @@ import type { TreeNode } from 'primevue/treenode';
 import { debounce } from '@/lib/utils';
 import LoButton from '@/components/LoButton.vue';
 import { useToast } from 'primevue/usetoast';
+import RequestWebIdPopup from '@/components/popups/RequestWebIdPopup.vue';
 
 const toast = useToast();
 
@@ -98,8 +117,13 @@ watch(selectedPodUrl, async (newPodUrl) => {
         width: 100%;
     }
 
-    &>.p-select {
+    & .p-select {
         height: min-content;
+        width: 100%;
+    }
+
+    & .input-label {
+        display: flex;
     }
 }
 </style>

--- a/loama/src/views/RequestView.vue
+++ b/loama/src/views/RequestView.vue
@@ -6,7 +6,8 @@
         </div>
         <Tree v-model:selectionKeys="selectedEntries" :value="requestableFiles" selectionMode="checkbox"
             class="w-full md:w-[30rem]" />
-        <LoButton>Request Access</LoButton>
+        <LoButton @click="sendRequestNotification" :disabled="Object.keys(selectedEntries).length < 1">Request Access
+        </LoButton>
     </div>
 </template>
 <script setup lang="ts">
@@ -41,6 +42,12 @@ const accessRequestNodeToTreeNode = (key: string, node: ResourceAccessRequestNod
         children: node.children ? Object.entries(node.children).map(([k, node]) => accessRequestNodeToTreeNode(k, node)) : undefined,
     }
 };
+
+const sendRequestNotification = () => {
+    const session = getDefaultSession();
+    const checkedEntries = Object.keys(selectedEntries.value).filter(k => selectedEntries.value[k].checked)
+    controller.value.AccessRequest().sendRequestNotification(session.info.webId!, checkedEntries)
+}
 
 watch(webId, async (newVal) => {
     debouncedPodFetcher(newVal);

--- a/loama/src/views/RequestView.vue
+++ b/loama/src/views/RequestView.vue
@@ -21,6 +21,9 @@ import Tree, { type TreeSelectionKeys } from 'primevue/tree';
 import type { TreeNode } from 'primevue/treenode';
 import { debounce } from '@/lib/utils';
 import LoButton from '@/components/LoButton.vue';
+import { useToast } from 'primevue/usetoast';
+
+const toast = useToast();
 
 const webId = ref("");
 const podUrls = ref<string[]>([]);
@@ -43,10 +46,24 @@ const accessRequestNodeToTreeNode = (key: string, node: ResourceAccessRequestNod
     }
 };
 
-const sendRequestNotification = () => {
+const sendRequestNotification = async () => {
     const session = getDefaultSession();
     const checkedEntries = Object.keys(selectedEntries.value).filter(k => selectedEntries.value[k].checked)
-    controller.value.AccessRequest().sendRequestNotification(session.info.webId!, checkedEntries)
+    try {
+        await controller.value.AccessRequest().sendRequestNotification(session.info.webId!, checkedEntries)
+        toast.add({
+            severity: "success",
+            summary: "Access request(s) sended to user",
+            life: 3000,
+        })
+    } catch (e) {
+        console.error(e);
+        toast.add({
+            severity: "error",
+            summary: `Failed to send access request: ${e instanceof Error ? e.message : e}`,
+            life: 3000,
+        })
+    }
 }
 
 watch(webId, async (newVal) => {

--- a/loama/src/views/RequestView.vue
+++ b/loama/src/views/RequestView.vue
@@ -72,7 +72,7 @@ const sendRequestNotification = async () => {
         await controller.value.AccessRequest().sendRequestNotification(session.info.webId!, checkedEntries)
         toast.add({
             severity: "success",
-            summary: "Access request(s) sended to user",
+            summary: "Access request(s) sent to user",
             life: 3000,
         })
     } catch (e) {

--- a/solid-common-lib/src/index.ts
+++ b/solid-common-lib/src/index.ts
@@ -11,9 +11,12 @@ export { url } from "./types";
  * @returns The URL's to the pods the user has access to
  */
 export async function listPodUrls(session: Session): Promise<url[]> {
-    const webId = session.info.webId!
+    return listWebIdPodUrls(session.info.webId!, session.fetch);
+}
+
+export async function listWebIdPodUrls(webId: string, fetch?: typeof globalThis.fetch): Promise<url[]> {
     const urls = await getPodUrlAll(webId, {
-        fetch: session.fetch,
+        fetch,
     });
 
     const fetchedUrl = await fetchStorageTriple(webId);

--- a/yarn.lock
+++ b/yarn.lock
@@ -527,6 +527,11 @@
     jose "^5.1.3"
     uuid "^10.0.0"
 
+"@inrupt/solid-client-errors@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@inrupt/solid-client-errors/-/solid-client-errors-0.0.1.tgz#e93c1d6b0f2b728f4d886b5b9eb2d068b1cbbb82"
+  integrity sha512-7OgjR6pdNVZEVZptL/2EzOWOArjFARg60ogiH/pFUkWSaiyx5bU//WG+pjlBlxiGJSXdxHOZ0lvH6zGv/p7rmQ==
+
 "@inrupt/solid-client@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@inrupt/solid-client/-/solid-client-2.0.1.tgz#103c1f2b75f1710d67180c2f28f3d2a609408527"
@@ -539,6 +544,22 @@
     jsonld-streaming-parser "^3.3.0"
     n3 "^1.17.2"
     uuid "^9.0.1"
+  optionalDependencies:
+    fsevents "^2.3.3"
+
+"@inrupt/solid-client@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@inrupt/solid-client/-/solid-client-2.1.0.tgz#28a05b9219168d07ebc13f8c961d84f013d10428"
+  integrity sha512-nUvgmS8UbxMzID9+CIHh2xrwpnZNmbXsmbSoO0kQjSt7ufhDmggeovmnBVH5WjtzG6Gy+aZUyW/RH8SltAawRQ==
+  dependencies:
+    "@inrupt/solid-client-errors" "^0.0.1"
+    "@rdfjs/dataset" "^1.1.1"
+    buffer "^6.0.3"
+    http-link-header "^1.1.1"
+    jsonld-context-parser "^3.0.0"
+    jsonld-streaming-parser "^3.3.0"
+    n3 "^1.17.2"
+    uuid "^10.0.0"
   optionalDependencies:
     fsevents "^2.3.3"
 
@@ -2457,6 +2478,16 @@ jsonld-context-parser@^2.4.0:
     "@types/http-link-header" "^1.0.1"
     "@types/node" "^18.0.0"
     cross-fetch "^3.0.6"
+    http-link-header "^1.0.2"
+    relative-to-absolute-iri "^1.0.5"
+
+jsonld-context-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jsonld-context-parser/-/jsonld-context-parser-3.0.0.tgz#43992862fc3eabcee9940cf4c44bb2b0dbe2542c"
+  integrity sha512-Kg6TVtBUdIm057ht/8WNhM9BROt+BeYaDGXbzrKaa3xA99csee+CsD8IMCTizRgzoO8PIzvzcxxCoRvpq1xNQw==
+  dependencies:
+    "@types/http-link-header" "^1.0.1"
+    "@types/node" "^18.0.0"
     http-link-header "^1.0.2"
     relative-to-absolute-iri "^1.0.5"
 


### PR DESCRIPTION
Adds access request & inbox tabs to handle:
- requesting certain permissions from requestable files
- Visualizing incoming request & logic to accept or reject these request
- An inbox with the response on the request to get certain permissions

## How to test
I've used firefox built-in container tabs to prevent the need of 2 dev server running in the background.

closes #9 